### PR TITLE
Fix incorrect logo URL

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -36,7 +36,7 @@
 				alt="Fork me on GitHub"
 				data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png">
 			</a>
-			<img src="/assets/images/logo-title.svg" class="project-logo" width="3rem" height="3rem">
+			<img src="assets/images/logo-title.svg" class="project-logo" width="3rem" height="3rem">
 			<h1 class="project-name"><script type="text/javascript">document.write(gheHostname())</script> Statistics</h1>
 		</section>
 		{% include navigation.html %}

--- a/docs/assets/css/stylesheet.css
+++ b/docs/assets/css/stylesheet.css
@@ -65,10 +65,6 @@ a {
 .project-logo {
   width: 3rem;
   height: 3rem;
-  background-image: url("../images/logo-title.svg");
-  background-size: 3rem;
-  background-repeat: no-repeat;
-  background-position: center center;
   align-self: center;
   margin-right: 2rem;
   margin-top: 1rem;


### PR DESCRIPTION
Unfortunately, I referenced the logo with an absolute URL, which doesn’t work on the hosted page at [autodesk.github.io/hubble](). Also, I accidentally included the logo twice. This pull requests corrects these issues to make the logo render properly.