### PR TITLE
Update GitHub audit log path for GitHub Enterprise 2.11

### DIFF
--- a/updater/scripts/api-requests.sh
+++ b/updater/scripts/api-requests.sh
@@ -4,7 +4,7 @@
 #
 echo -e "resource\ttype\tsource IP\trequests/day"
 
-zcat -f /var/log/haproxy.log.1* |
+zcat -f /var/log/haproxy.log* |
     perl -ne 'print if s/.*: ([^:]+).*\/api\/v3\/([^\/\? ]+)\/([^\/\? ]+?(\/[^\/\? ]+)).*/\1 \2 \3/' |
     sort |
     uniq -c |

--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -4,7 +4,7 @@
 #
 echo -e "repository\tuser\tcloning?\trequests/day\tdownload/day [B]"
 
-zcat -f /var/log/github/audit.log.1* |
+zcat -f /var/log/github-audit.log.1* |
     perl -ne 'print if s/.*"program":"upload-pack".*"repo_name":"([^"]+).*"user_login":"([^"]+).*"cloning":([^,]+).*"uploaded_bytes":([^ ]+).*/\1\t\2\t\3\t\4/' |
     sort |
     perl -ne '$S{$1} += $2 and $C{$1} += 1 if (/^(.+)\t(\d+)$/);END{printf("%s\t%i\t%i\n",$_,$C{$_},$S{$_}) for ( keys %S );}' |

--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -4,7 +4,7 @@
 #
 echo -e "repository\tuser\tcloning?\trequests/day\tdownload/day [B]"
 
-zcat -f /var/log/github-audit.log.1* |
+zcat -f /var/log/github-audit.log* |
     perl -ne 'print if s/.*"program":"upload-pack".*"repo_name":"([^"]+).*"user_login":"([^"]+).*"cloning":([^,]+).*"uploaded_bytes":([^ ]+).*/\1\t\2\t\3\t\4/' |
     sort |
     perl -ne '$S{$1} += $2 and $C{$1} += 1 if (/^(.+)\t(\d+)$/);END{printf("%s\t%i\t%i\n",$_,$C{$_},$S{$_}) for ( keys %S );}' |

--- a/updater/scripts/git-requests.sh
+++ b/updater/scripts/git-requests.sh
@@ -4,7 +4,7 @@
 #
 echo -e "repository\tsource IP\trequests/day"
 
-zcat -f /var/log/babeld/babeld.log.1* |
+zcat -f /var/log/babeld/babeld.log* |
     perl -ne 'print if s/.*ip=([^ ]+).*repo=([^ ]+).*/\1 \2/' |
     sort |
     uniq -c |

--- a/updater/scripts/git-versions.sh
+++ b/updater/scripts/git-versions.sh
@@ -4,7 +4,7 @@
 #
 echo -e "Git version\tusers"
 
-zgrep -hF '||git/' /var/log/haproxy.log.1* |
+zgrep -hF '||git/' /var/log/haproxy.log* |
 	perl -lape 's/.* (.*):.* \[.*\|\|git\/(\d+(?:\.\d+){0,2}).*/$1 $2/' |
 	sort |
 	uniq |

--- a/updater/scripts/tokenless-auth.sh
+++ b/updater/scripts/tokenless-auth.sh
@@ -5,7 +5,7 @@
 #
 echo -e "user\trepository\ttokenless authentications/day"
 
-zcat -f /var/log/github/gitauth.log.1* |
+zcat -f /var/log/github/gitauth.log* |
     perl -ne 'print if s/.*status=OK member="?([^ "]+) hashed_token=nil.*path=([^ ]+)\.git .*proto=http.*/\1 \2/' |
     sort |
     uniq -c |


### PR DESCRIPTION
on ghe 2.11.2 the github-audit path is a link (/var/log/github/audit.log) to /var/log/github-audit.log

this leads to an empty git-download.tsv and an empty result in hubble/housekeeping-git-traffic.

Rotated logs are kept as /var/log/github/audit.log.[1-9].*
This pr changes the ghe-audit log path in hubble/updater/script/gith-download.sh from
/var/log/github/audit.log.1*  ->  /var/log/github-audit.log.1*