### PR TITLE
add support for GHE 2.11 audit log location

### DIFF
--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -2,9 +2,26 @@
 #
 # Calculate download traffic per day
 #
+
+function ghe_greater_equal () {
+    cat /etc/github/enterprise-release |
+        perl -sne '
+            use version;
+            my ($installed) = $_ =~ /RELEASE_VERSION="([0-9]+([.][0-9]+)+)"/;
+            exit (version->parse($installed) ge version->parse($required));
+        ' -- -required="$1"
+    return $?
+}
+
+if ghe_greater_equal "2.11" ; then
+    LOG_FILE="/var/log/github-audit.log"
+else
+    LOG_FILE="/var/log/github/audit.log"
+fi
+
 echo -e "repository\tuser\tcloning?\trequests/day\tdownload/day [B]"
 
-zcat -f /var/log/github-audit.log.1* |
+zcat -f $LOG_FILE.1* |
     perl -ne 'print if s/.*"program":"upload-pack".*"repo_name":"([^"]+).*"user_login":"([^"]+).*"cloning":([^,]+).*"uploaded_bytes":([^ ]+).*/\1\t\2\t\3\t\4/' |
     sort |
     perl -ne '$S{$1} += $2 and $C{$1} += 1 if (/^(.+)\t(\d+)$/);END{printf("%s\t%i\t%i\n",$_,$C{$_},$S{$_}) for ( keys %S );}' |

--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -4,7 +4,7 @@
 #
 echo -e "repository\tuser\tcloning?\trequests/day\tdownload/day [B]"
 
-zcat -f /var/log/github/audit.log.1* |
+zcat -f /var/log/github-audit.log.1* |
     perl -ne 'print if s/.*"program":"upload-pack".*"repo_name":"([^"]+).*"user_login":"([^"]+).*"cloning":([^,]+).*"uploaded_bytes":([^ ]+).*/\1\t\2\t\3\t\4/' |
     sort |
     perl -ne '$S{$1} += $2 and $C{$1} += 1 if (/^(.+)\t(\d+)$/);END{printf("%s\t%i\t%i\n",$_,$C{$_},$S{$_}) for ( keys %S );}' |


### PR DESCRIPTION
In GHE 2.11 the audit log location was changed. Check the GHE version
to support pre 2.11 log location and the new log location.