### PR TITLE
Set “license” header in readme in title case

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ These are the humans that form the core team of Hubble Enterprise, in alphabetic
 | [![](https://avatars3.githubusercontent.com/u/477434?v=4&s=100)](https://github.com/larsxschneider)<br><sub>[@larsxschneider](https://github.com/larsxschneider)</sub> | [![](https://avatars1.githubusercontent.com/u/3244280?v=4&s=100)](https://github.com/pluehne)<br><sub>[@pluehne](https://github.com/pluehne)</sub> |
 |---|---|
 
-## LICENSE
+## License
 
 SPDX-License-Identifier: [MIT](LICENSE.md)


### PR DESCRIPTION
The other section headers in the readme are all in title case. For this reason, the “license” section header should also be set in title case.