### PR TITLE
Cleanup GHE URL in header

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -35,7 +35,7 @@
 			</a>
 			<a href="{{ site.baseurl }}/" alt="Hubble Enterprise">
 				<img src="{{ site.baseurl }}/assets/images/logo-title.svg" class="project-logo" width="3rem" height="3rem">
-				<h1 class="project-name">{{ site.url | remove_first: "https://" | remove: "http://" }} Statistics</h1>
+				<h1 class="project-name">{{ site.url | replace: "://pages.", "://" | remove_first: "https://" | remove_first: "http://" }} Statistics</h1>
 			</a>
 		</section>
 		{% include navigation.html %}


### PR DESCRIPTION
If GHE subdomain isolation is enabled, then all pages URLs are 
prefixed with `pages.`. Remove this prefix in the page header. 

In addition, only remove the first occurrences of `http://` (although we 
shouldn't see that string multiple times).

@parkr is there an easier way to achieve the same? 😄 

/cc @GitHugop 