### PR TITLE
Readability of graph descriptions

### DIFF
--- a/docs/assets/css/stylesheet.css
+++ b/docs/assets/css/stylesheet.css
@@ -383,11 +383,13 @@ a
 .row
 {
 	width: 100%;
+	margin-bottom: 1rem;
 }
 
 .row .col-main
 {
 	width: 100%;
+	margin-bottom: 1rem;
 }
 
 .row .col-main svg
@@ -400,7 +402,14 @@ a
 .row .col-aside
 {
 	margin-top: 1rem;
+	margin-bottom: 1rem;
 	width: 100%;
+	clear: both;
+}
+
+.row .col-aside :last-child
+{
+	margin-bottom: 0;
 }
 
 .info-box
@@ -408,16 +417,6 @@ a
 	background-color: #f5f5f5;
 	border-radius: 0.5rem;
 	margin-bottom: 1rem;
-}
-
-.info-box:last-child
-{
-	margin-bottom: 0;
-}
-
-.row .col-aside:last-child
-{
-	margin-bottom: 0;
 }
 
 .info-box p
@@ -449,27 +448,43 @@ a
 
 	.row
 	{
-		display: flex;
-		align-items: flex-start;
+		clear: both;
 	}
 
-	.row-centered
+	.row::after
 	{
-		align-items: center;
+		content: "";
+		clear: both;
+		display: table;
 	}
 
 	.row .col-main
 	{
+		float: left;
+		clear: left;
 		width: 75%;
+		vertical-align: middle;
 		padding-right: 0.5rem;
 	}
 
 	.row .col-aside
 	{
+		vertical-align: top;
+		float: right;
+		clear: right;
 		width: 25%;
 		margin-top: 0;
 		padding-top: 0;
 		padding-left: 0.5rem;
+	}
+
+	.row-centered
+	{
+	}
+
+	.row-centered .col-aside
+	{
+		vertical-align: middle;
 	}
 }
 

--- a/docs/housekeeping-api-requests.html
+++ b/docs/housekeeping-api-requests.html
@@ -7,6 +7,13 @@ permalink: /housekeeping-api-requests
 <h3>API Requests</h3>
 
 <div class="row">
+  <div class="col-aside">
+		<div class="info-box">
+			<p>
+				The total number of <a href="https://developer.github.com/">GitHub API requests</a>.
+			</p>
+    </div>
+  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -19,9 +26,6 @@ permalink: /housekeeping-api-requests
 	<div class="col-aside">
 		<div class="info-box">
 			<p>
-				The total number of <a href="https://developer.github.com/">GitHub API requests</a>.
-			</p>
-			<p>
 				High numbers usually indicate unfavorably configured CI processes.
 			</p>
 		</div>
@@ -29,17 +33,17 @@ permalink: /housekeeping-api-requests
 </div>
 
 <div class="row">
-	<div class="col-main">
-		<table
-			class="table"
-			data-url="{{ site.dataURL }}/api-requests-detailed.tsv"
-		></table>
-	</div>
-	<div class="col-aside">
+  <div class="col-aside">
 		<div class="info-box">
 			<p>
 				This table lists the resources requested via the API that accounted for the majority of API requests yesterday.
 			</p>
 		</div>
+	</div>
+	<div class="col-main">
+		<table
+			class="table"
+			data-url="{{ site.dataURL }}/api-requests-detailed.tsv"
+		></table>
 	</div>
 </div>

--- a/docs/housekeeping-api-requests.html
+++ b/docs/housekeeping-api-requests.html
@@ -5,15 +5,12 @@ permalink: /housekeeping-api-requests
 ---
 
 <h3>API Requests</h3>
-
+<div class="info-box">
+	<p>
+		The total number of <a href="https://developer.github.com/">GitHub API requests</a>.
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				The total number of <a href="https://developer.github.com/">GitHub API requests</a>.
-			</p>
-    </div>
-  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -33,17 +30,17 @@ permalink: /housekeeping-api-requests
 </div>
 
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				This table lists the resources requested via the API that accounted for the majority of API requests yesterday.
-			</p>
-		</div>
-	</div>
 	<div class="col-main">
 		<table
 			class="table"
 			data-url="{{ site.dataURL }}/api-requests-detailed.tsv"
 		></table>
+	</div>
+	<div class="col-aside">
+		<div class="info-box">
+			<p>
+				This table lists the resources requested via the API that accounted for the majority of API requests yesterday.
+			</p>
+		</div>
 	</div>
 </div>

--- a/docs/housekeeping-api-requests.html
+++ b/docs/housekeeping-api-requests.html
@@ -5,12 +5,15 @@ permalink: /housekeeping-api-requests
 ---
 
 <h3>API Requests</h3>
-<div class="info-box">
-	<p>
-		The total number of <a href="https://developer.github.com/">GitHub API requests</a>.
-	</p>
-</div>
+
 <div class="row">
+	<div class="col-aside">
+		<div class="info-box">
+			<p>
+				The total number of <a href="https://developer.github.com/">GitHub API requests</a>.
+			</p>
+		</div>
+	</div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -21,6 +24,21 @@ permalink: /housekeeping-api-requests
 		</div>
 	</div>
 	<div class="col-aside">
+		<div class="info-box">
+			<p>
+				High numbers usually indicate unfavorably configured CI processes.
+			</p>
+		</div>
+		<div class="info-box">
+			<p>
+				High numbers usually indicate unfavorably configured CI processes.
+			</p>
+		</div>
+		<div class="info-box">
+			<p>
+				High numbers usually indicate unfavorably configured CI processes.
+			</p>
+		</div>
 		<div class="info-box">
 			<p>
 				High numbers usually indicate unfavorably configured CI processes.

--- a/docs/housekeeping-git-requests.html
+++ b/docs/housekeeping-git-requests.html
@@ -7,6 +7,13 @@ permalink: /housekeeping-git-requests
 <h3>Git Requests</h3>
 
 <div class="row">
+  <div class="col-aside">
+		<div class="info-box">
+			<p>
+				The total number of Git requests (includes pushes, fetches, and clones).
+			</p>
+    </div>
+  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -19,9 +26,6 @@ permalink: /housekeeping-git-requests
 	<div class="col-aside">
 		<div class="info-box">
 			<p>
-				The total number of Git requests (includes pushes, fetches, and clones).
-			</p>
-			<p>
 				High numbers usually indicate unfavorably configured CI processes.
 			</p>
 		</div>
@@ -29,17 +33,17 @@ permalink: /housekeeping-git-requests
 </div>
 
 <div class="row">
-	<div class="col-main">
-		<table
-			class="table"
-			data-url="{{ site.dataURL }}/git-requests-detailed.tsv"
-		></table>
-	</div>
-	<div class="col-aside">
+  <div class="col-aside">
 		<div class="info-box">
 			<p>
 				This table lists the repositories that accounted for the majority of Git requests yesterday.
 			</p>
 		</div>
+	</div>
+	<div class="col-main">
+		<table
+			class="table"
+			data-url="{{ site.dataURL }}/git-requests-detailed.tsv"
+		></table>
 	</div>
 </div>

--- a/docs/housekeeping-git-requests.html
+++ b/docs/housekeeping-git-requests.html
@@ -5,15 +5,12 @@ permalink: /housekeeping-git-requests
 ---
 
 <h3>Git Requests</h3>
-
+<div class="info-box">
+	<p>
+		The total number of Git requests (includes pushes, fetches, and clones).
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				The total number of Git requests (includes pushes, fetches, and clones).
-			</p>
-    </div>
-  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -33,17 +30,17 @@ permalink: /housekeeping-git-requests
 </div>
 
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				This table lists the repositories that accounted for the majority of Git requests yesterday.
-			</p>
-		</div>
-	</div>
 	<div class="col-main">
 		<table
 			class="table"
 			data-url="{{ site.dataURL }}/git-requests-detailed.tsv"
 		></table>
+	</div>
+	<div class="col-aside">
+		<div class="info-box">
+			<p>
+				This table lists the repositories that accounted for the majority of Git requests yesterday.
+			</p>
+		</div>
 	</div>
 </div>

--- a/docs/housekeeping-git-traffic.html
+++ b/docs/housekeeping-git-traffic.html
@@ -37,15 +37,12 @@ permalink: /housekeeping-git-traffic
 </div>
 
 <h3>Transferred Data</h3>
-
+<div class="info-box">
+	<p>
+		The amount of data transferred for clones and fetches.
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				The amount of data transferred for clones and fetches.
-			</p>
-    </div>
-  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -71,17 +68,17 @@ permalink: /housekeeping-git-traffic
 </div>
 
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				This table lists the repositories that accounted for the majority of the traffic yesterday.
-			</p>
-		</div>
-	</div>
 	<div class="col-main">
 		<table
 			class="table"
 			data-url="{{ site.dataURL }}/git-download-detailed.tsv"
 		></table>
+	</div>
+	<div class="col-aside">
+		<div class="info-box">
+			<p>
+				This table lists the repositories that accounted for the majority of the traffic yesterday.
+			</p>
+		</div>
 	</div>
 </div>

--- a/docs/housekeeping-git-traffic.html
+++ b/docs/housekeeping-git-traffic.html
@@ -39,6 +39,13 @@ permalink: /housekeeping-git-traffic
 <h3>Transferred Data</h3>
 
 <div class="row">
+  <div class="col-aside">
+		<div class="info-box">
+			<p>
+				The amount of data transferred for clones and fetches.
+			</p>
+    </div>
+  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -57,9 +64,6 @@ permalink: /housekeeping-git-traffic
 	<div class="col-aside">
 		<div class="info-box">
 			<p>
-				The amount of data transferred for clones and fetches.
-			</p>
-			<p>
 				To save resources, you should try to minimize the number of clones, especially for large repositories.
 			</p>
 		</div>
@@ -67,17 +71,17 @@ permalink: /housekeeping-git-traffic
 </div>
 
 <div class="row">
-	<div class="col-main">
-		<table
-			class="table"
-			data-url="{{ site.dataURL }}/git-download-detailed.tsv"
-		></table>
-	</div>
-	<div class="col-aside">
+  <div class="col-aside">
 		<div class="info-box">
 			<p>
 				This table lists the repositories that accounted for the majority of the traffic yesterday.
 			</p>
 		</div>
+	</div>
+	<div class="col-main">
+		<table
+			class="table"
+			data-url="{{ site.dataURL }}/git-download-detailed.tsv"
+		></table>
 	</div>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,12 +4,14 @@ title: Collaboration
 permalink: /
 ---
 <h3>Collaboration Across Organizations</h3>
-<div class="info-box">
-	<p>
-		The top 50&nbsp;connections between organizations over the last two years.
-	</p>
-</div>
 <div class="row row-centered">
+	<div class="col-aside">
+		<div class="info-box">
+			<p>
+				The top 50&nbsp;connections between organizations over the last two years.
+			</p>
+		</div>
+	</div>
 	<div class="col-main">
 		<svg
 			width="1000"

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,11 @@ permalink: /
 <h3>Collaboration Across Organizations</h3>
 
 <div class="row row-centered">
+  <div class="info-box">
+    <p>
+      The top 50&nbsp;connections between organizations over the last two years.
+    </p>
+  </div>
 	<div class="col-main">
 		<svg
 			width="1000"
@@ -21,9 +26,6 @@ permalink: /
 			</p>
 		</div>
 		<div class="info-box">
-			<p>
-				The top 50&nbsp;connections between organizations over the last two years.
-			</p>
 			<p>
 				A connection between two organizations is rated higher the more people contribute to both organizations.
 				Users are considered <em>members</em> of an organization if the majority of their pushes were made to this organization.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,13 +4,12 @@ title: Collaboration
 permalink: /
 ---
 <h3>Collaboration Across Organizations</h3>
-
+<div class="info-box">
+	<p>
+		The top 50&nbsp;connections between organizations over the last two years.
+	</p>
+</div>
 <div class="row row-centered">
-  <div class="info-box">
-    <p>
-      The top 50&nbsp;connections between organizations over the last two years.
-    </p>
-  </div>
 	<div class="col-main">
 		<svg
 			width="1000"

--- a/docs/pr-total.html
+++ b/docs/pr-total.html
@@ -5,15 +5,12 @@ permalink: /pr-total
 ---
 
 <h3>Pull Requests (Total, by Week)</h3>
-
+<div class="info-box">
+	<p>
+		The total number of merged and new pull requests.
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				The total number of merged and new pull requests.
-			</p>
-		</div>
-	</div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -36,15 +33,12 @@ permalink: /pr-total
 </div>
 
 <h3>Pull Requests (Last Month, by Repository)</h3>
-
+<div class="info-box">
+	<p>
+		The top 20 repositories with the most merged or new pull requests in the last month.
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				The top 20 repositories with the most merged or new pull requests in the last month.
-			</p>
-		</div>
-	</div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -70,15 +64,12 @@ permalink: /pr-total
 </div>
 
 <h3>Pull Requests (Last Month, by Organization)</h3>
-
+<div class="info-box">
+	<p>
+		The top 20 organizations with the most merged or new pull requests in the last month.
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				The top 20 organizations with the most merged or new pull requests in the last month.
-			</p>
-		</div>
-	</div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas

--- a/docs/pr-total.html
+++ b/docs/pr-total.html
@@ -7,6 +7,13 @@ permalink: /pr-total
 <h3>Pull Requests (Total, by Week)</h3>
 
 <div class="row">
+  <div class="col-aside">
+		<div class="info-box">
+			<p>
+				The total number of merged and new pull requests.
+			</p>
+		</div>
+	</div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -26,18 +33,18 @@ permalink: /pr-total
 				></canvas>
 		</div>
 	</div>
-	<div class="col-aside">
-		<div class="info-box">
-			<p>
-				The total number of merged and new pull requests.
-			</p>
-		</div>
-	</div>
 </div>
 
 <h3>Pull Requests (Last Month, by Repository)</h3>
 
 <div class="row">
+  <div class="col-aside">
+		<div class="info-box">
+			<p>
+				The top 20 repositories with the most merged or new pull requests in the last month.
+			</p>
+		</div>
+	</div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -60,18 +67,18 @@ permalink: /pr-total
 				></canvas>
 		</div>
 	</div>
-	<div class="col-aside">
-		<div class="info-box">
-			<p>
-				The top 20 repositories with the most merged or new pull requests in the last month.
-			</p>
-		</div>
-	</div>
 </div>
 
 <h3>Pull Requests (Last Month, by Organization)</h3>
 
 <div class="row">
+  <div class="col-aside">
+		<div class="info-box">
+			<p>
+				The top 20 organizations with the most merged or new pull requests in the last month.
+			</p>
+		</div>
+	</div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -92,13 +99,6 @@ permalink: /pr-total
 					]
 				}'
 				></canvas>
-		</div>
-	</div>
-	<div class="col-aside">
-		<div class="info-box">
-			<p>
-				The top 20 organizations with the most merged or new pull requests in the last month.
-			</p>
 		</div>
 	</div>
 </div>

--- a/docs/pr-usage.html
+++ b/docs/pr-usage.html
@@ -5,15 +5,12 @@ permalink: /pr-usage
 ---
 
 <h3>Pull Request Usage</h3>
-
+<div class="info-box">
+	<p>
+		The percentage of active repositories located in organizations, having more than one contributor, and using pull requests for contributions.
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-    <div class="info-box">
-      <p>
-        The percentage of active repositories located in organizations, having more than one contributor, and using pull  requests for contributions.
-      </p>
-    </div>
-  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas

--- a/docs/pr-usage.html
+++ b/docs/pr-usage.html
@@ -7,6 +7,13 @@ permalink: /pr-usage
 <h3>Pull Request Usage</h3>
 
 <div class="row">
+  <div class="col-aside">
+    <div class="info-box">
+      <p>
+        The percentage of active repositories located in organizations, having more than one contributor, and using pull  requests for contributions.
+      </p>
+    </div>
+  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -18,9 +25,6 @@ permalink: /pr-usage
 	</div>
 	<div class="col-aside">
 		<div class="info-box">
-			<p>
-				The percentage of active repositories located in organizations, having more than one contributor, and using pull requests for contributions.
-			</p>
 			<p>
 				In this context, <em>active</em> designates repositories with at least two pushes in the last four weeks.
 			</p>

--- a/docs/users-contributors.html
+++ b/docs/users-contributors.html
@@ -4,15 +4,12 @@ title: Contributors
 permalink: /users-contributors
 ---
 <h3>Contributors (Last Month, by Repository)</h3>
-
+<div class="info-box">
+	<p>
+		The top 20 repositories with the most contributors.
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-    <div class="info-box">
-      <p>
-        The top 20 repositories with the most contributors.
-      </p>
-    </div>
-  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -26,15 +23,12 @@ permalink: /users-contributors
 </div>
 
 <h3>Contributors (Last Month, by Organization)</h3>
-
+<div class="info-box">
+	<p>
+		The top 20 organizations with the most contributors.
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-		<div class="info-box">
-			<p>
-				The top 20 organizations with the most contributors.
-			</p>
-		</div>
-	</div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas

--- a/docs/users-contributors.html
+++ b/docs/users-contributors.html
@@ -6,6 +6,13 @@ permalink: /users-contributors
 <h3>Contributors (Last Month, by Repository)</h3>
 
 <div class="row">
+  <div class="col-aside">
+    <div class="info-box">
+      <p>
+        The top 20 repositories with the most contributors.
+      </p>
+    </div>
+  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -16,18 +23,18 @@ permalink: /users-contributors
 			></canvas>
 		</div>
 	</div>
-	<div class="col-aside">
-		<div class="info-box">
-			<p>
-				The top 20 repositories with the most contributors.
-			</p>
-		</div>
-	</div>
 </div>
 
 <h3>Contributors (Last Month, by Organization)</h3>
 
 <div class="row">
+  <div class="col-aside">
+		<div class="info-box">
+			<p>
+				The top 20 organizations with the most contributors.
+			</p>
+		</div>
+	</div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -36,13 +43,6 @@ permalink: /users-contributors
 				data-type="list"
 				data-config='{"sliceData": [0, 20]}'
 			></canvas>
-		</div>
-	</div>
-	<div class="col-aside">
-		<div class="info-box">
-			<p>
-				The top 20 organizations with the most contributors.
-			</p>
 		</div>
 	</div>
 </div>

--- a/docs/users-git-versions.html
+++ b/docs/users-git-versions.html
@@ -6,6 +6,13 @@ permalink: /users-git-versions
 <h3>Git Versions</h3>
 
 <div class="row">
+  <div class="col-aside">
+    <div class="info-box">
+      <p>
+        Shows how many users signed in with which Git version.
+      </p>
+    </div>
+  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas
@@ -13,13 +20,6 @@ permalink: /users-git-versions
 				data-url="{{ site.dataURL }}/git-versions.tsv"
 				data-type="list"
 			></canvas>
-		</div>
-	</div>
-	<div class="col-aside">
-		<div class="info-box">
-			<p>
-				Shows how many users signed in with which Git version.
-			</p>
 		</div>
 	</div>
 </div>

--- a/docs/users-git-versions.html
+++ b/docs/users-git-versions.html
@@ -4,15 +4,12 @@ title: Git
 permalink: /users-git-versions
 ---
 <h3>Git Versions</h3>
-
+<div class="info-box">
+	<p>
+		Shows how many users signed in with which Git version.
+	</p>
+</div>
 <div class="row">
-  <div class="col-aside">
-    <div class="info-box">
-      <p>
-        Shows how many users signed in with which Git version.
-      </p>
-    </div>
-  </div>
 	<div class="col-main">
 		<div class="chart-container">
 			<canvas


### PR DESCRIPTION
👋  Autodesk, @pluehne and @larsxschneider

I noticed when i was looking through the graphs ( 😍  they're amazing ) that the description of some of the graphs were underneath the graph themselves, and some graphs can be quite long (`users-git-versions` specifically comes to mind). My proposal is to move these short descriptions (where applicable) to the top of the graph so they don't need to scroll to the bottom of the graph.

## TODO
- [x] convert spaces back to tabs (sorry!)