### PR TITLE
Improved user interaction with chart tooltips

### DIFF
--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -80,6 +80,11 @@ var timeSeriesChartDefaults =
 			}
 		]
 	},
+	tooltips:
+	{
+		mode: "x",
+		intersect: false,
+	},
 };
 
 var barChartDefaults =


### PR DESCRIPTION
The time series chart tooltips were a bit clunky.
The area in which the cursor had to be to invoke the tooltips was very small, and the tooltips
showed only one data entry at a time, making comparisons hard.

This commit changes that by showing tooltips already when the cursor hovers a date (hitting the exact data points is not necessary anymore), with all the data points available for that specific x position.

![screenshot](https://user-images.githubusercontent.com/3244280/31890924-1fc84216-b805-11e7-932f-772a2db6d68f.png)