### PR TITLE
git-download: fix GHE version detection

### DIFF
--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -8,12 +8,12 @@ function ghe_greater_equal () {
         perl -sne '
             use version;
             my ($installed) = $_ =~ /RELEASE_VERSION="([0-9]+([.][0-9]+)+)"/;
-            exit (version->parse($installed) ge version->parse($required));
+            exit (version->parse($installed) lt version->parse($required));
         ' -- -required="$1"
     return $?
 }
 
-if ghe_greater_equal "2.11" ; then
+if ghe_greater_equal "2.11.0" ; then
     LOG_FILE="/var/log/github-audit.log"
 else
     LOG_FILE="/var/log/github/audit.log"


### PR DESCRIPTION
An exit code of 0 indicates success and an exit code of 1 indicates
failure in bash. Flip the version comparision operator in Perl to
implement "ghe_greater_equal" properly.

In addition, define the required version with three segments as this
seems to be required by the Perl version parser.

Thanks to @toddocon for pointing out the issue to me!

---

Unfortunately, this does not yet fix the download graph for GHE 2.11.
It looks like the log rotation frequency for /var/log/github-audit.log
changed from daily to weekly. I've asked GH support if this change
was intentional. If yes, then we need to adjust our audit log data 
gathering as the current code expects the daily rotation.