### PR TITLE
Collaboration chart: draw chosen org first, make first org blue

### DIFF
--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -548,6 +548,28 @@ function visualizeSingleOrg(orgs, matrix, orgID) {
 		}
 	}
 
+	// Make the single org the first entry in the matrix to ensure that it
+	// always gets the same color in the chart.
+	if (orgID != 0) {
+		let t = orgs[orgID];
+		orgs[orgID] = orgs[0];
+		orgs[0] = t;
+		for (let x = matrix.length - 1; x >= 0; x--) {
+			for (let y = matrix[0].length - 1; y >= 0; y--) {
+				if (x == orgID) {
+					let t = matrix[x][y];
+					matrix[x][y] = matrix[0][y];
+					matrix[0][y] = t;
+				}
+				if (y == orgID) {
+					let t = matrix[x][y];
+					matrix[x][y] = matrix[x][0];
+					matrix[x][0] = t;
+				}
+			}
+		}
+	}
+
 	drawCoord(orgs, matrix);
 }
 


### PR DESCRIPTION
If the collaboration chart of a single organization is visualized, then
ensure that the choosen org is always drawn first. This way the choosen
org is always drawn with the same color.

In addition, rotate the color wheel to start with the color "blue"
because I think it looks good.