### PR TITLE
Hyphenate within info boxes only

### DIFF
--- a/docs/assets/css/stylesheet.css
+++ b/docs/assets/css/stylesheet.css
@@ -305,10 +305,6 @@ a
 	overflow: auto;
 	word-break: keep-all;
 	word-break: normal;
-}
-
-.main-content table
-{
 	border-top: 4px solid #e9ebec;
 	border-bottom: 4px solid #e9ebec;
 }

--- a/docs/assets/css/stylesheet.css
+++ b/docs/assets/css/stylesheet.css
@@ -1,7 +1,6 @@
 *
 {
 	box-sizing: border-box;
-	hyphens: auto;
 }
 
 body
@@ -408,6 +407,7 @@ a
 	background-color: #f5f5f5;
 	border-radius: 0.5rem;
 	margin-bottom: 1rem;
+	hyphens: auto;
 }
 
 .info-box:last-child


### PR DESCRIPTION
Previously, hyphenation was enabled for all HTML elements in the dashboard. However, this is not very helpful with organization names, as it’s important to know whether the organization name contains an extra hyphen or not.

For this reason, this commit enables hyphenation for info boxes only, for which hyphenation was originally intended, as the text columns within info boxes are rather small.

Aside from that, I smuggled in a minor cleanup commit (6c000aa2f6f2583ae245bdd4598601556d793922).