### PR TITLE
Add anchors to items in first table columns

### DIFF
--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -377,10 +377,19 @@ function createTable(table)
 							case "repository":
 							case "resource":
 							case "user":
-								cell.append("a")
+								let a = cell.append("a").text(entry)
 									.attr("target", "_blank")
 									.attr("href", gheUrl() + "/" + entry)
 									.text(entry);
+
+								const tableID = d3.select(table).attr("id");
+								const prefix = (tableID ? (tableID + "-") : "");
+
+								// Add anchors, but only for the first column,
+								// which is usually unique
+								if (i == 0)
+									a.attr("id", prefix + entry);
+
 								break;
 							default:
 								cell.append().text(entry);

--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -392,7 +392,7 @@ function createTable(table)
 
 								break;
 							default:
-								cell.append().text(entry);
+								cell.text(entry);
 						}
 					}
 				});


### PR DESCRIPTION
This adds anchors to items in the first columns of tables. This is useful, for instance, to send links directly referencing a row in the tables (where the first column usually some sort of index).

To disambiguate the anchor IDs in the case that there are multiple tables on the same page, anchors are automatically prefixed with the table’s own ID.

Additionally, 06d39d1117b4e1f4f147509b24eca4d4c25eb5ed fixes the HTML output. Previously, tabes introduced tags of type `<undefined>` whenever the table cell content wasn’t a link.