### PR TITLE
fix Git download chart for GHE 2.11.0

### DIFF
--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -15,13 +15,20 @@ function ghe_greater_equal () {
 
 if ghe_greater_equal "2.11.0" ; then
     LOG_FILE="/var/log/github-audit.log"
+    # The "github-audit.log" log file introduced in GHE 2.11.0 is only rolled
+    # once a week. This was reported as a bug and is likely fixed in an
+    # upcoming version. In the meantime we grep for all log entries that have
+    # been written yesterday.
+    GREP_YESTERDAY="grep -F '$(date --date='yesterday' +'%b %d')'"
 else
     LOG_FILE="/var/log/github/audit.log"
+    GREP_YESTERDAY="tee"
 fi
 
 echo -e "repository\tuser\tcloning?\trequests/day\tdownload/day [B]"
 
 zcat -f $LOG_FILE.1* |
+    eval "$GREP_YESTERDAY" |
     perl -ne 'print if s/.*"program":"upload-pack".*"repo_name":"([^"]+).*"user_login":"([^"]+).*"cloning":([^,]+).*"uploaded_bytes":([^ ]+).*/\1\t\2\t\3\t\4/' |
     sort |
     perl -ne '$S{$1} += $2 and $C{$1} += 1 if (/^(.+)\t(\d+)$/);END{printf("%s\t%i\t%i\n",$_,$C{$_},$S{$_}) for ( keys %S );}' |


### PR DESCRIPTION
The "github-audit.log" log file introduced in GHE 2.11.0 is only rolled
once a week. This was reported as bug and is likely fixed in an upcoming
version. In the meantime we grep for all log entries that have been
written yesterday.