### PR TITLE
Backward compatibility for excludedEntities config

### DIFF
--- a/updater/update-stats.py
+++ b/updater/update-stats.py
@@ -48,6 +48,10 @@ def main():
 	if len(sys.argv) > 1 and sys.argv[1] == "--dry-run":
 		configuration["dryRun"] = True
 
+	# Make excludedEntities a list if it isn’t already (for backward compatibility)
+	if not isinstance(configuration["excludedEntities"], list):
+		configuration["excludedEntities"] = [configuration["excludedEntities"]]
+
 	print("Preparing update of GitHub usage statistics", file = sys.stderr)
 	sys.stderr.flush()
 


### PR DESCRIPTION
The configuration option `excludedEntities` is now a list and not a pure string anymore. In order not to break existing systems, automatically make a list out of the setting if it isn’t already.

I deliberately implemented this in [`update-stats.py`](updater/update-stats.py) and not in the [`addExcludedEntities`](https://github.com/Autodesk/hubble/blob/c782eee822f80a70b61b8fb9e66ec40653d0e644/updater/reports/Report.py#L205-L210) function (where it’s used) in order to make the change consistent—should this setting be read at another place, for instance.