### PR TITLE
Fix Git download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ The **docs** component visualizes the collected data with [GitHub Pages](https:/
    You may want to bookmark this URL to conveniently access the dashboard of Hubble Enterprise.
 1. [Configure the updater component](updater/README.md).
 
-## Known Issues
-
-* The [Git traffic chart](https://autodesk.github.io/hubble/housekeeping-git-traffic) generates wrong results with GitHub Enterprise 2.11.0, as GitHub changed the rotation of the relevant log file from daily to weekly.
-We reported the problem and hope they fix it soon.
-
 ## Contributing
 
 Review [the contributing guidelines](CONTRIBUTING.md) before you consider working on Hubble Enterprise and proposing contributions.

--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -14,23 +14,20 @@ function ghe_greater_equal () {
 }
 
 if ghe_greater_equal "2.11.0" ; then
-    # check the two most recent log files
-    CAT_LOG_FILE="zcat -f /var/log/github-audit.log{,.1*}"
     # The "github-audit.log" log file introduced in GHE 2.11.0 is only rolled
     # once a week. This was reported as a bug and is likely fixed in an
-    # upcoming version. In the meantime we grep for all log entries that have
-    # been written yesterday.
-    GREP_YESTERDAY="grep -F '$(date --date='yesterday' +'%b %d')'"
+    # upcoming version. In the meantime, we grep for all log entries in the two
+    # most recent log files (because the information from yesterday may or not
+    # be rotated already).
+    CAT_LOG_FILE="zcat -f /var/log/github-audit.log{,.1*} | grep -F '$(date --date='yesterday' +'%b %d')'"
 else
     # check yesterday’s log file
     CAT_LOG_FILE="zcat -f /var/log/github/audit.log.1*"
-    GREP_YESTERDAY="tee"
 fi
 
 echo -e "repository\tuser\tcloning?\trequests/day\tdownload/day [B]"
 
 eval "$CAT_LOG_FILE" |
-    eval "$GREP_YESTERDAY" |
     perl -ne 'print if s/.*"program":"upload-pack".*"repo_name":"([^"]+).*"user_login":"([^"]+).*"cloning":([^,]+).*"uploaded_bytes":([^ ]+).*/\1\t\2\t\3\t\4/' |
     sort |
     perl -ne '$S{$1} += $2 and $C{$1} += 1 if (/^(.+)\t(\d+)$/);END{printf("%s\t%i\t%i\n",$_,$C{$_},$S{$_}) for ( keys %S );}' |


### PR DESCRIPTION
This fixes an issue where the log files read by Hubble were empty, which is why the Git download report got 0 traffic as a result.

This lets the Git download script check not only for log entries in the previous Git audit log but also the current one. Because of the unwanted log rotation change introduced in GitHub Enterprise 2.11, we can’t assume that the log files searched for with .1* contain yesterday’s information (it might still reside in the current, not-yet-rotated log).

I tested this on a GitHub Enterprise 2.11.2 machine, and I’m confident that this doesn’t break 2.10 support.