### PR TITLE
Fix user names in tokenless authentications script

### DIFF
--- a/updater/scripts/tokenless-auth.sh
+++ b/updater/scripts/tokenless-auth.sh
@@ -10,5 +10,4 @@ zcat -f /var/log/github/gitauth.log.1* |
     sort |
     uniq -c |
     sort -rn |
-    awk '{printf("%s\t%s\t%s\n",$2,$3,$1)}' |
-    awk '{gsub(/[_.]/, "-", $1)}1'
+    awk '{gsub(/[_.]/, "-", $2); printf("%s\t%s\t%s\n",$2,$3,$1)}'

--- a/updater/scripts/tokenless-auth.sh
+++ b/updater/scripts/tokenless-auth.sh
@@ -10,4 +10,5 @@ zcat -f /var/log/github/gitauth.log.1* |
     sort |
     uniq -c |
     sort -rn |
-    awk '{printf("%s\t%s\t%s\n",$2,$3,$1)}'
+    awk '{printf("%s\t%s\t%s\n",$2,$3,$1)}' |
+    awk '{gsub(/[_.]/, "-", $1)}1'


### PR DESCRIPTION
In this script, user names were read from LDAP, where underscores and periods are allowed characters. However, these characters aren’t allowed in GitHub user names, which is why they are replaced with dashes.

Because of this, user names containing underscores and periods weren’t linked correctly in the tokenless authentications list. This pull request fixes this by performing the substitution directly within the affected script.