### PR TITLE
api-requests: fix haproxy IP address parsing

### DIFF
--- a/updater/scripts/api-requests.sh
+++ b/updater/scripts/api-requests.sh
@@ -5,7 +5,7 @@
 echo -e "resource\ttype\tsource IP\trequests/day"
 
 zcat -f /var/log/haproxy.log.1* |
-    perl -ne 'print if s/.*: ([^:]+).*\/api\/v3\/([^\/\? ]+)\/([^\/\? ]+?(\/[^\/\? ]+)).*/\1 \2 \3/' |
+    perl -ne 'print if s/.*haproxy\[\d+\]: ([^:]+).*\/api\/v3\/([^\/\? ]+)\/([^\/\? ]+?(\/[^\/\? ]+)).*/\1 \2 \3/' |
     sort |
     uniq -c |
     sort -rn |


### PR DESCRIPTION
The IP address is parsed with a greedy search for ":" in the haproxy
logs. Apparently GitHub Enterprise adds other colons in some situations
that confuse this search. E.g. "Operation: California" in this example:
```
Nov 23 15:12:08 octodemo-com-primary haproxy[27650]: 127.0.0.1:60001 [23/Nov/2017:15:12:08.418] https_protocol~ web_unicorns/localhost 0/0/0/79/79 200 45447 - - ---- 13/6/1/1/0 0/0 {octodemo.com||Operation: California Auto-Deploy} "GET /api/v3/repos/lukeartorg/reading-time-demo-lukeart/deployments HTTP/1.1"
```
Narrow the regex pattern to detect the IP address properly.

Reported-by: Johannes Nicolai <@jonico>