### PR TITLE
git-download: fix audit log grepping workaround for GHE 2.11+

### DIFF
--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -19,7 +19,7 @@ if ghe_greater_equal "2.11.0" ; then
     # upcoming version. In the meantime, we grep for all log entries in the two
     # most recent log files (because the information from yesterday may or not
     # be rotated already).
-    CAT_LOG_FILE="zcat -f /var/log/github-audit.log{,.1*} | grep -F '$(date --date='yesterday' +'%b %d')'"
+    CAT_LOG_FILE="zcat -f /var/log/github-audit.log{,.1*} | grep -F '$(date --date='yesterday' +'%b %_d')'"
 else
     # check yesterday’s log file
     CAT_LOG_FILE="zcat -f /var/log/github/audit.log.1*"


### PR DESCRIPTION
In 50743c8 we implemented a workaround for the GitHub audit log rotation
bug. The solution was to find the log lines from yesterday in the files
that contain all logs from the last week. To achieve this we grep for
yesterday's date.

The day component of the date was padded with zeros (e.g. "Dec 04").
However, in the GitHub audit log the date is padded with spaces (e.g.
"Dec  4"). Consequently, the grep did not match for single digit days.

Fix that by padding the day with spaces.