### PR TITLE
git-download: print audit logs in chronological order

### DIFF
--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -19,7 +19,7 @@ if ghe_greater_equal "2.11.0" ; then
     # upcoming version. In the meantime, we grep for all log entries in the two
     # most recent log files (because the information from yesterday may or not
     # be rotated already).
-    CAT_LOG_FILE="zcat -f /var/log/github-audit.log{,.1*} | grep -F '$(date --date='yesterday' +'%b %_d')'"
+    CAT_LOG_FILE="zcat -f /var/log/github-audit.{log.1*,log} | grep -F '$(date --date='yesterday' +'%b %_d')'"
 else
     # check yesterday’s log file
     CAT_LOG_FILE="zcat -f /var/log/github/audit.log.1*"


### PR DESCRIPTION
Using "log{,.1*}" would print the ".log" file first and afterwards the
".log.1*". This would break the chronocial order (see example below).
Fix this problem by defining the order explitcly.

This problem did not affect the current implementation. However, I think
printing the log items in chronological order is a good idea to avoid
surprises in the future.

Example:

$ zcat -f /var/log/github-audit.log{,.1*} | cut -c -6 | uniq -c
 146 Dec  3
 238 Dec  4
 138 Dec  5
 190 Nov 27
 264 Nov 28
 250 Nov 29
 249 Nov 30
 233 Dec  1
 189 Dec  2
  52 Dec  3

$ zcat -f /var/log/github-audit.{log.1*,log} | cut -c -6 | uniq -c
 190 Nov 27
 264 Nov 28
 250 Nov 29
 249 Nov 30
 233 Dec  1
 189 Dec  2
 199 Dec  3
 238 Dec  4
 138 Dec  5