### PR TITLE
Fixes #20: adds a spinner during graph load

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -26,6 +26,7 @@
 		<script src="https://d3js.org/d3.v4.min.js"></script>
 		<script src="https://momentjs.com/downloads/moment-with-locales.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
 		<script src="{{ site.baseurl }}/assets/js/charts.js?version=1ff0187"></script>
 	</head>
 	<body>

--- a/docs/assets/css/stylesheet.css
+++ b/docs/assets/css/stylesheet.css
@@ -382,6 +382,7 @@ a
 
 .row .col-main
 {
+	position: relative;
 	width: 100%;
 }
 

--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -115,10 +115,18 @@ var stackedBarChartDefaults =
 	maintainAspectRatio: false
 };
 
+function createSpinner(canvas)
+{
+	var parent = $("<div style=\"position:absolute;height:100%;width:100%;\"></div>");
+	parent.insertBefore($(canvas));
+	return new Spinner().spin(parent[0]);
+}
+
 function createHistoryChart(canvas)
 {
 	var url = $(canvas).data("url");
 
+	var spinner = createSpinner(canvas);
 	d3.tsv(url,
 		function(row)
 		{
@@ -228,6 +236,8 @@ function createHistoryChart(canvas)
 					},
 					options: timeSeriesChartDefaults
 				});
+		}).on("load.spinner", function() {
+			spinner.stop();
 		});
 }
 
@@ -235,6 +245,7 @@ function createList(canvas)
 {
 	var url = $(canvas).data("url");
 
+	var spinner = createSpinner(canvas);
 	d3.tsv(url,
 		function(row)
 		{
@@ -312,6 +323,8 @@ function createList(canvas)
 					},
 					options: options
 				});
+		}).on("load.spinner", function() {
+			spinner.stop();
 		});
 }
 
@@ -327,6 +340,7 @@ function createTable(table)
 {
 	var url = $(table).data("url");
 
+	var spinner = createSpinner(table);
 	d3.tsv(url,
 		function(error, data)
 		{
@@ -396,6 +410,8 @@ function createTable(table)
 						}
 					}
 				});
+		}).on("load.spinner", function() {
+			spinner.stop();
 		});
 }
 
@@ -596,6 +612,7 @@ function createCollaborationChart(canvas)
 {
 	const url = $(canvas).data("url");
 	const quota = 50;
+	var spinner = createSpinner(canvas);
 
 	d3.text(url,
 		function(text)
@@ -634,7 +651,9 @@ function createCollaborationChart(canvas)
 
 			menuChanged();
 		}
-	);
+	).on("load.spinner", function() {
+		spinner.stop();
+	});
 }
 
 $(window).bind("load", function()


### PR DESCRIPTION
This PR addresses #20: display a loading indicator while Hubble is off fetching data.

# Changes

- Leverages [spin.js](http://spin.js.org/) for the spinner, so I added it to the layout template
- The main column element's CSS had to be tweaked to use relative positioning
- Each function creating each type of graph was tweaked to:
  a) create a spinner
  b) hide the spinner once network request completes

# Considerations

- What to do if the async net request for data errors? Currently, nothing happens, so the spinners keep on spinning.

# Testing It

I pointed the `_config.yml` file to `http://localhost:4000/demo-data`, then ran `jekyll serve` from the `docs/` folder. I loaded up http://localhost:4000 in Chrome, and using the Chrome Developer Tools' Network tab, I set the simulated network speed to "Slow 3G", then refreshed the page. That network profile was slow enough for me to be able to ensure that the spinner does show up relatively centered over where incoming graphs will be rendered to.