### PR TITLE
Fixes #62: spinner container gets in the way of mouseover events with charts

### DIFF
--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -119,7 +119,13 @@ function createSpinner(canvas)
 {
 	let parent = $("<div style=\"position:absolute;height:100%;width:100%;\"></div>");
 	parent.insertBefore($(canvas));
-	return new Spinner().spin(parent[0]);
+	let spinner = new Spinner().spin(parent[0]);
+	return {
+		stop: function() {
+			spinner.stop();
+			parent.remove();
+		}
+	};
 }
 
 function createHistoryChart(canvas)

--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -117,7 +117,7 @@ var stackedBarChartDefaults =
 
 function createSpinner(canvas)
 {
-	let parent = $("<div style=\"position:absolute;height:100%;width:100%;\"></div>");
+	let parent = $("<div style=\"position:absolute;height:100%;width:100%;\" class=\"spinner-container\"></div>");
 	parent.insertBefore($(canvas));
 	let spinner = new Spinner().spin(parent[0]);
 	return {

--- a/docs/spec/charts.js
+++ b/docs/spec/charts.js
@@ -1,4 +1,4 @@
-/* global createCollaborationChart, createHistoryChart, createList, createTable */
+/* global createCollaborationChart, createHistoryChart, createList, createTable, createSpinner */
 
 describe("global charts.js", function() {
 	describe("createCollaborationChart function", function() {
@@ -19,6 +19,31 @@ describe("global charts.js", function() {
 	describe("createTable function", function() {
 		it("should exist", function() {
 			expect(createTable).toBeDefined();
+		});
+	});
+	describe("createSpinner function", function() {
+		let canvas;
+		beforeEach(function() {
+			canvas = $("<div id=\"test\"></div>");
+			$("body").append(canvas);
+		});
+		afterEach(function() {
+			canvas.remove();
+		});
+		it("should exist", function() {
+			expect(createSpinner).toBeDefined();
+		});
+		it("should return an object with a stop method", function() {
+			let spinner = createSpinner(canvas[0]);
+			expect(spinner.stop).toBeDefined();
+			spinner.stop();
+		});
+		describe("stop method", function() {
+			it("should destroy the spinner container after execution", function() {
+				let spinner = createSpinner(canvas[0]);
+				spinner.stop();
+				expect($(".spinner-container").length).toEqual(0);
+			});
 		});
 	});
 });

--- a/docs/spec/karma.conf.js
+++ b/docs/spec/karma.conf.js
@@ -25,6 +25,7 @@ module.exports = function(config) {
       'assets/js/vendor/d3.v4.min.js',
       'assets/js/vendor/moment-with-locales.min.js',
       'assets/js/vendor/Chart-2.7.1.min.js',
+      'assets/js/vendor/spin-2.3.2.min.js',
       'assets/js/charts.js',
       'spec/*.js'
     ],


### PR DESCRIPTION
Sorry about the bug with the spinner, my bad!

I've fixed that in this pull request by ensuring we remove the container housing the spinner from the DOM after calling `stop` on it. I also added a test for this to our new test framework to ensure we don't regress on this in the future :)