### PR TITLE
Switch updater to systemd system service

### DIFF
--- a/updater/README.md
+++ b/updater/README.md
@@ -34,12 +34,12 @@ The updater may be run in two modes:
 1. Create a config file in `/opt/autodesk/hubble-enterprise/config.py` (based on `[config.py.example](config.py.example)`).
 1. Enable and start the **periodic** updater process (persistently, survives reboots):
 	```sh
-	systemctl --user enable hubble-enterprise.timer
-	systemctl --user start hubble-enterprise.timer
+	sudo systemctl enable hubble-enterprise.timer
+	sudo systemctl start hubble-enterprise.timer
 	```
 1. Optionally, you may **trigger** the updater process (just once):
 	```sh
-	systemctl --user start hubble-enterprise.service
+	sudo systemctl start hubble-enterprise.service
 	```
 
 #### Upgrading
@@ -54,14 +54,14 @@ The updater may be run in two modes:
 	```
 1. If the `systemd` files (the service or timer file) have changed, let systemd adapt to the changes:
 	```sh
-	systemctl --user daemon-reexec
+	sudo systemctl daemon-reexec
 	```
 
 #### Uninstallation
 
 1. Disable the **periodic** updater process:
 	```sh
-	systemctl --user disable hubble-enterprise.timer
+	sudo systemctl disable hubble-enterprise.timer
 	```
 1. Remove the package:
 	```sh
@@ -72,7 +72,7 @@ The updater may be run in two modes:
 
 The updater’s log is accessible as follows:
 ```sh
-journalctl -f --user-unit hubble-enterprise.service
+journalctl -fu hubble-enterprise.service
 ```
 
 #### Debian Packaging

--- a/updater/packaging/debian/templates/Makefile
+++ b/updater/packaging/debian/templates/Makefile
@@ -2,7 +2,7 @@ all: # nothing to build
 
 PKGNAME = hubble-enterprise
 INSTALLDIR = $(DESTDIR)/opt/autodesk/$(PKGNAME)
-SYSTEMDDIR = $(DESTDIR)/home/admin/.local/share/systemd/user
+SYSTEMDDIR = $(DESTDIR)/usr/lib/systemd/system
 BASEDIR=../../../..
 
 install:

--- a/updater/systemd/hubble-enterprise.service
+++ b/updater/systemd/hubble-enterprise.service
@@ -1,8 +1,14 @@
 [Unit]
 Description=Hubble Enterprise updater
-After=mysql.service
+Requires=github-enterprise.target
+After=github-enterprise.target
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/python3 /opt/autodesk/hubble-enterprise/update-stats.py
 WorkingDirectory=/opt/autodesk/hubble-enterprise/
+User=admin
+Group=admin
+
+[Install]
+WantedBy=github-enterprise.target

--- a/updater/systemd/hubble-enterprise.timer
+++ b/updater/systemd/hubble-enterprise.timer
@@ -1,10 +1,11 @@
 [Unit]
 Description=Runs Hubble Enterprise updater periodically
+Requires=github-enterprise.target
+After=github-enterprise.target
 
 [Timer]
 OnCalendar=7:30
 Persistent=true
-Unit=hubble-enterprise.service
 
 [Install]
-WantedBy=default.target
+WantedBy=github-enterprise.target


### PR DESCRIPTION
This makes the `systemd` system service a user service. There are two reasons that motivated this change.

1. User services require an active session of the specified user. This has the drawback that the updater would not be triggered after reboots if no SSH connection to the GitHub Enterprise appliance was made (see also #71, which should be fixed by this pull request).
1. User services cannot depend on system services. Because of that, the updater service could not reliably wait for the rest of GitHub Enterprise to start.