### PR TITLE
Fix dh_make call for Debian packaging

### DIFF
--- a/updater/packaging/debian/Makefile
+++ b/updater/packaging/debian/Makefile
@@ -12,7 +12,7 @@ all:	clean
 	cd $(BUILDDIR) && \
 	export DEBEMAIL=$(EMAIL) && \
 	export DEBFULLNAME=$(MAINTAINER) && \
-	python2 /usr/bin/dh_make -p $(PKGNAME)_$(PKGVERSION) -i --native -c mit -y && \
+	python /usr/bin/dh_make -p $(PKGNAME)_$(PKGVERSION) -i --native -c mit -y && \
 	dpkg-buildpackage -rfakeroot -d -us -uc
 	mkdir -p $(PKGDIR)
 	mv $(BUILDDIR)/../*.deb $(PKGDIR)/


### PR DESCRIPTION
`dh_make` recently changed from Python 2 to Python 3. For this reason, the call to `dh_make` with Python 2 won’t work on systems with new `dh_make` versions. Instead of locking the Python version to Python 2, call Python without the fixed version number. This should be safe, because we can expect Linux distributions to ship a version of `dh_make` that works with the system’s default Python version.