### PR TITLE
use ASCII only characters in scripts

### DIFF
--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -21,7 +21,7 @@ if ghe_greater_equal "2.11.0" ; then
     # be rotated already).
     CAT_LOG_FILE="zcat -f /var/log/github-audit.{log.1*,log} | grep -F '$(date --date='yesterday' +'%b %_d')'"
 else
-    # check yesterday’s log file
+    # check yesterday's log file
     CAT_LOG_FILE="zcat -f /var/log/github/audit.log.1*"
 fi
 


### PR DESCRIPTION
Some Python version apparently cannot handle Unicode characters which
causes the following error:

```
    File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
       return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 881: ordinal not in range(128)
```

Fix this by using ASCII only characters.

Thanks to @rajivmucheli for patiently debugging the issue with me 😄 