### PR TITLE
Fix .gitignore path

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,7 +1,7 @@
 _site
 
 # You can clone your "hubble-data" repository to this location for debugging
-hubble-data
+demo-data
 
 # nodejs bits
 node_modules


### PR DESCRIPTION
This corrects the `.gitignore` path to the demo data directory, which was moved from `hubble-data` to `demo-data` earlier in e406ee5f10930f24367cbdc800362eeee907fa46.