### PR TITLE
Fix typo in chord chart code

### DIFF
--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -461,7 +461,7 @@ function createTable(table)
     });
 }
 
-function drawCoord(orgs, matrix)
+function drawChord(orgs, matrix)
 {
     function fadeRibbon(opacity)
     {
@@ -689,7 +689,7 @@ function visualizeOrgsWithTopConnections(orgs, matrix, quota)
         }
     }
 
-    drawCoord(orgs, matrix);
+    drawChord(orgs, matrix);
 }
 
 function visualizeSingleOrg(orgs, matrix, orgID)
@@ -730,7 +730,7 @@ function visualizeSingleOrg(orgs, matrix, orgID)
         }
     }
 
-    drawCoord(orgs, matrix);
+    drawChord(orgs, matrix);
 }
 
 function createChordChart(canvas)


### PR DESCRIPTION
The function “drawChord” was accidentally misspelled. I believe that it wasn’t *coordinates* that were meant but [*chords*](https://en.wikipedia.org/wiki/Chord_(geometry)), a term from geometry signifying line segments whose endpoints both reside on a circle.