### PR TITLE
Make the “raw data” button optional

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ For details on how each kind of chart is rendered, take a look at [`charts.js`](
 | `visibleSeries ` | array of strings | only show the listed data series and hide all others initially (referenced by TSV table headings) |
 | `sliceData ` | array `[t0, t1]` | slice the data from the TSV file as if `data.slice(t0, t1)` was called |
 | `aggregate ` | weekly | if set to `weekly`, aggregate the data by week by computing the sum of the values within each week |
+| `showRawDataLink` | `true`, `false` | show the link to download the chart’s raw data (default: `true`) |
 
 ##### List Charts
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,10 +46,10 @@ For details on how each kind of chart is rendered, take a look at [`charts.js`](
 
 | option | values | description |
 |---|---|---|
-|  `series ` | array of strings | only include these data series and drop all others (referenced by TSV table headings) |
-|  `visibleSeries ` | array of strings | only show the listed data series and hide all others initially (referenced by TSV table headings) |
-|  `sliceData ` | array `[t0, t1]` | slice the data from the TSV file as if `data.slice(t0, t1)` was called |
-|  `aggregate ` | weekly | if set to `weekly`, aggregate the data by week by computing the sum of the values within each week |
+| `series ` | array of strings | only include these data series and drop all others (referenced by TSV table headings) |
+| `visibleSeries ` | array of strings | only show the listed data series and hide all others initially (referenced by TSV table headings) |
+| `sliceData ` | array `[t0, t1]` | slice the data from the TSV file as if `data.slice(t0, t1)` was called |
+| `aggregate ` | weekly | if set to `weekly`, aggregate the data by week by computing the sum of the values within each week |
 
 ##### List Charts
 

--- a/docs/assets/css/stylesheet.css
+++ b/docs/assets/css/stylesheet.css
@@ -399,6 +399,11 @@ a
 	width: 100%;
 }
 
+.row h3
+{
+	margin: 0;
+}
+
 .info-box
 {
 	background-color: #f5f5f5;
@@ -641,11 +646,6 @@ a
 {
 	margin-top: 4rem;
 	margin-bottom: 1rem;
-}
-
-.action-bar h3
-{
-	margin: 0;
 }
 
 button,

--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -820,7 +820,7 @@ $(window).bind('load', function()
             const infoBoxes = $(chartPlaceholder).find('.info-box');
 
             // Put a bar with the title and additional actions before the chart container
-            if ($(charts.first()).attr('data-url'))
+            if (readConfig($(charts.first()), 'showRawDataLink') != false && $(charts.first()).attr('data-url'))
             {
                 titles.insertBefore(chartPlaceholder).wrapAll(
                     '<div class="row action-bar"><div class="col-main"></div></div>');

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,7 @@ permalink: /
 		height="1000"
 		data-url="{{ site.dataURL }}/org-collaboration.tsv"
 		data-type="chord"
+		data-config='{"showRawDataLink": false}'
 	></svg>
 	<div class="info-box">
 		<p>


### PR DESCRIPTION
This introduces a new configuration option “showRawDataLink,” through which the “raw data” button can be explicitly hidden (requested in #87).

This is used for hiding the “raw data” download button in the collaboration chart, where the raw data isn’t useful to view or edit in a spreadsheet application.

Also, the margins of chart titles were incorrect in the case that the corresponding action bar was hidden. This change applies the same style to all titles, regardless of whether an action bar is shown or not.

See how the “raw data” button is missing in the screenshot below 😄:

![screenshot from 2018-01-23 14-19-05](https://user-images.githubusercontent.com/3244280/35277920-9eac5cb2-0048-11e8-8a71-6259237746ea.png)