### PR TITLE
Use GitHub build hash as parameter on assets

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,29 +5,29 @@
 		<meta charset="UTF-8">
 		<title>Hubble Enterprise{% if page.title %}: {{ page.title }}{% endif %}</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<link rel="icon" sizes="256x256" href="{{ site.baseurl }}/assets/icons/favicon-256x256.png?version=7c4fcab">
-		<link rel="icon" sizes="192x192" href="{{ site.baseurl }}/assets/icons/favicon-192x192.png?version=7c4fcab">
-		<link rel="icon" sizes="128x128" href="{{ site.baseurl }}/assets/icons/favicon-128x128.png?version=7c4fcab">
-		<link rel="icon" sizes="96x96" href="{{ site.baseurl }}/assets/icons/favicon-96x96.png?version=7c4fcab">
-		<link rel="icon" sizes="64x64" href="{{ site.baseurl }}/assets/icons/favicon-64x64.png?version=7c4fcab">
-		<link rel="icon" sizes="48x48" href="{{ site.baseurl }}/assets/icons/favicon-48x48.png?version=7c4fcab">
-		<link rel="icon" sizes="32x32" href="{{ site.baseurl }}/assets/icons/favicon-32x32.png?version=7c4fcab">
-		<link rel="icon" sizes="16x16" href="{{ site.baseurl }}/assets/icons/favicon-16x16.png?version=7c4fcab">
-		<link rel="apple-touch-icon" sizes="57x57" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-57x57.png?version=7c4fcab">
-		<link rel="apple-touch-icon" sizes="76x76" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-76x76.png?version=7c4fcab">
-		<link rel="apple-touch-icon" sizes="120x120" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-120x120.png?version=7c4fcab">
-		<link rel="apple-touch-icon" sizes="152x152" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-152x152.png?version=7c4fcab">
-		<link rel="apple-touch-icon" sizes="167x167" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-167x167.png?version=7c4fcab">
-		<link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-180x180.png?version=7c4fcab">
-		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/normalize.css?version=7c4fcab" media="screen">
+		<link rel="icon" sizes="256x256" href="{{ site.baseurl }}/assets/icons/favicon-256x256.png?version={{ site.github.build_revision }}">
+		<link rel="icon" sizes="192x192" href="{{ site.baseurl }}/assets/icons/favicon-192x192.png?version={{ site.github.build_revision }}">
+		<link rel="icon" sizes="128x128" href="{{ site.baseurl }}/assets/icons/favicon-128x128.png?version={{ site.github.build_revision }}">
+		<link rel="icon" sizes="96x96" href="{{ site.baseurl }}/assets/icons/favicon-96x96.png?version={{ site.github.build_revision }}">
+		<link rel="icon" sizes="64x64" href="{{ site.baseurl }}/assets/icons/favicon-64x64.png?version={{ site.github.build_revision }}">
+		<link rel="icon" sizes="48x48" href="{{ site.baseurl }}/assets/icons/favicon-48x48.png?version={{ site.github.build_revision }}">
+		<link rel="icon" sizes="32x32" href="{{ site.baseurl }}/assets/icons/favicon-32x32.png?version={{ site.github.build_revision }}">
+		<link rel="icon" sizes="16x16" href="{{ site.baseurl }}/assets/icons/favicon-16x16.png?version={{ site.github.build_revision }}">
+		<link rel="apple-touch-icon" sizes="57x57" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-57x57.png?version={{ site.github.build_revision }}">
+		<link rel="apple-touch-icon" sizes="76x76" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-76x76.png?version={{ site.github.build_revision }}">
+		<link rel="apple-touch-icon" sizes="120x120" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-120x120.png?version={{ site.github.build_revision }}">
+		<link rel="apple-touch-icon" sizes="152x152" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-152x152.png?version={{ site.github.build_revision }}">
+		<link rel="apple-touch-icon" sizes="167x167" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-167x167.png?version={{ site.github.build_revision }}">
+		<link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-180x180.png?version={{ site.github.build_revision }}">
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/normalize.css?version={{ site.github.build_revision }}" media="screen">
 		<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i" media="screen">
-		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/stylesheet.css?version=df12dbc" media="screen">
+		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/stylesheet.css?version={{ site.github.build_revision }}" media="screen">
 		<script src="{{ site.baseurl }}/assets/js/vendor/jquery-3.2.1.min.js"></script>
 		<script src="{{ site.baseurl }}/assets/js/vendor/d3.v4.min.js"></script>
 		<script src="{{ site.baseurl }}/assets/js/vendor/moment-with-locales.min.js"></script>
 		<script src="{{ site.baseurl }}/assets/js/vendor/Chart-2.7.1.min.js"></script>
 		<script src="{{ site.baseurl }}/assets/js/vendor/spin-2.3.2.min.js"></script>
-		<script src="{{ site.baseurl }}/assets/js/charts.js?version=1ff0187"></script>
+		<script src="{{ site.baseurl }}/assets/js/charts.js?version={{ site.github.build_revision }}"></script>
 	</head>
 	<body>
 		<section class="page-header">


### PR DESCRIPTION
By using the GitHub Pages build hash as a “version” parameter on the asset URLs, we can force browser cache flushes of our JavaScript and CSS resources upon every commit.

While it wouldn’t be strictly necessary to change the version tag of a file on every commit (but only when it changes), this avoids having to manually change the version parameter after each change.

Note that I couldn’t test this yet, as I would have to replicate GitHub Pages somehow (maybe I could do this through a fork).

On another note, in the case that you deploy this locally, the variable `site.github.build_revision` will be rendered as an empty string. Not that that’s a problem from my point of view, but if you think this is something we should address, go ahead and tell me.