### PR TITLE
add list of personal repositories that non-owners are pushing to

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -45,6 +45,8 @@
       url: "/housekeeping-api-requests"
     - title: "Abandoned Organizations"
       url: "/housekeeping-abandoned-orgs"
+    - title: "Repository Location"
+      url: "/housekeeping-repo-location"
     - title: "Forks"
       url: "/housekeeping-forks"
 - title: "Recommendations"

--- a/docs/demo-data/repositories-personal-nonowner-pushes-detailed.tsv
+++ b/docs/demo-data/repositories-personal-nonowner-pushes-detailed.tsv
@@ -1,0 +1,3 @@
+repository
+alice/something
+bob/else

--- a/docs/demo-data/repositories-personal-nonowner-pushes.tsv
+++ b/docs/demo-data/repositories-personal-nonowner-pushes.tsv
@@ -1,0 +1,4 @@
+date	personal repositories with nonowner pushes
+2018-01-25	98
+2018-01-24	108
+2018-01-23	110

--- a/docs/housekeeping-repo-location.html
+++ b/docs/housekeeping-repo-location.html
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Repository Location
+permalink: /housekeeping-repo-location
+---
+
+<div class="chart-placeholder">
+	<h3>Personal Repositories with Nonowner Pushes in the Last 4 Weeks</h3>
+	<canvas
+		data-url="{{ site.dataURL }}/repositories-personal-nonowner-pushes.tsv"
+		data-type="history"
+	></canvas>
+	<div class="info-box">
+		<p>
+			Repositories in user accounts should only be pushed to by their owners, as these repositories might become unavailable or deleted if the owner leaves the company.
+		</p>
+		<p>
+			Repositories in which people actively collaborate should be <a href="https://help.github.com/articles/about-repository-transfers/">transferred</a> to an organization account.
+		</p>
+	</div>
+</div>
+
+<div class="chart-placeholder">
+	<table data-url="{{ site.dataURL }}/repositories-personal-nonowner-pushes-detailed.tsv"></table>
+</div>

--- a/updater/reports/ReportReposPersonalNonOwnerPushes.py
+++ b/updater/reports/ReportReposPersonalNonOwnerPushes.py
@@ -1,0 +1,38 @@
+from .ReportDaily import *
+
+# Find personal repositories that nonowners are pushing to.
+# These repositories should be moved into organizations.
+# Only look at active users (not suspended!) and only look at pushes
+# of the last 4 weeks.
+class ReportReposPersonalNonOwnerPushes(ReportDaily):
+	def name(self):
+		return "repositories-personal-nonowner-pushes"
+
+	def updateDailyData(self):
+		self.detailedHeader, self.detailedData = self.parseData(self.executeQuery(self.query()))
+		if len(self.data) == 0:
+			self.header = ["date", "personal repositories with nonowner pushes"]
+		self.data.append([str(self.yesterday()), len(self.detailedData)])
+		self.truncateData(self.timeRangeTotal())
+		self.sortDataByDate()
+
+	def query(self):
+		fourWeeksAgo = self.daysAgo(28)
+		query = '''
+			SELECT
+				CONCAT(users.login, "/", repositories.name) as "repository"
+			FROM
+				repositories
+				JOIN users ON repositories.owner_id = users.id
+				JOIN pushes ON pushes.repository_id = repositories.id
+			WHERE
+				users.type = "user"
+				AND users.suspended_at IS NULL
+				AND CAST(pushes.created_at AS DATE) BETWEEN "''' + str(fourWeeksAgo) + '''" AND "''' + str(self.yesterday()) + '''"
+				AND pushes.pusher_id != users.id
+			GROUP BY
+				repositories.id
+			ORDER BY
+				1
+		'''
+		return query

--- a/updater/update-stats.py
+++ b/updater/update-stats.py
@@ -24,6 +24,7 @@ from reports.ReportPRHistory import *
 from reports.ReportPRUsage import *
 from reports.ReportRepoActivity import *
 from reports.ReportRepositoryHistory import *
+from reports.ReportReposPersonalNonOwnerPushes import *
 from reports.ReportTeamsTotal import *
 from reports.ReportTokenlessAuth import *
 from reports.ReportUsers import *
@@ -95,6 +96,7 @@ def main():
 	ReportPRUsage(configuration, dataDirectory, metaStats).update()
 	ReportRepoActivity(configuration, dataDirectory, metaStats).update()
 	ReportRepositoryHistory(configuration, dataDirectory, metaStats).update()
+	ReportReposPersonalNonOwnerPushes(configuration, dataDirectory, metaStats).update()
 	ReportTeamsTotal(configuration, dataDirectory, metaStats).update()
 	ReportTokenlessAuth(configuration, dataDirectory, metaStats).update()
 	ReportUsers(configuration, dataDirectory, metaStats).update()


### PR DESCRIPTION
Find personal repositories that non-owners are pushing to.
These kind of repositories should be moved into organizations.
Only look at active users (not suspended!) and only look at pushes
of the last 4 weeks.