### PR TITLE
Replace text in “raw data” download button with icon

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -21,6 +21,7 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/assets/icons/apple-touch-icon-180x180.png?version={{ site.github.build_revision }}">
 		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/normalize.css?version={{ site.github.build_revision }}" media="screen">
 		<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i" media="screen">
+		<link rel="stylesheet" type="text/css" href="https://use.fontawesome.com/releases/v5.0.6/css/all.css" media="screen">
 		<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/stylesheet.css?version={{ site.github.build_revision }}" media="screen">
 		<script src="{{ site.baseurl }}/assets/js/vendor/jquery-3.2.1.min.js"></script>
 		<script src="{{ site.baseurl }}/assets/js/vendor/d3.v4.min.js"></script>

--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -897,7 +897,8 @@ $(window).bind('load', function()
 
                 // Add an action box as the first info box
                 const downloadLink = '<a class="button" href="' + $(charts.first()).attr('data-url')
-                                   + '" target="_blank">Raw data</a>';
+                                   + '" target="_blank" title="Download raw data">'
+                                   + '<i class="fas fa-download"></i></a>';
                 titles.parent().parent().append(
                     '<div class="col-aside"><div class="info-box"><p>' + downloadLink + '</p></div></div>');
             }


### PR DESCRIPTION
The “raw data” link was very verbose and, perhaps, not as easily recognizible for a download button than the Font Awesome download icon.

Replacing the text “raw data” with an icon also saves some space that we’ll need in the action bar to add a detail view switch.

![screenshot](https://user-images.githubusercontent.com/3244280/35515650-06d41706-050a-11e8-9e19-56b6f4b6b789.png)