### PR TITLE
count pusher in personal repos with nonowner pushes

### DIFF
--- a/docs/demo-data/repositories-personal-nonowner-pushes-detailed.tsv
+++ b/docs/demo-data/repositories-personal-nonowner-pushes-detailed.tsv
@@ -1,3 +1,3 @@
-repository
-alice/something
-bob/else
+repository	nonowner pushers
+alice/something	4
+bob/else	1

--- a/updater/reports/ReportReposPersonalNonOwnerPushes.py
+++ b/updater/reports/ReportReposPersonalNonOwnerPushes.py
@@ -20,7 +20,8 @@ class ReportReposPersonalNonOwnerPushes(ReportDaily):
 		fourWeeksAgo = self.daysAgo(28)
 		query = '''
 			SELECT
-				CONCAT(users.login, "/", repositories.name) as "repository"
+				CONCAT(users.login, "/", repositories.name) as "repository",
+				COUNT(DISTINCT(pushes.pusher_id)) as "nonowner pushers"
 			FROM
 				repositories
 				JOIN users ON repositories.owner_id = users.id
@@ -33,6 +34,6 @@ class ReportReposPersonalNonOwnerPushes(ReportDaily):
 			GROUP BY
 				repositories.id
 			ORDER BY
-				1
+				2 DESC, 1
 		'''
 		return query


### PR DESCRIPTION
The more people push to a personal repo, the more this repo should
become an organizational repo. Therefore, we count the number of
pushers and sort the "offender" list by it.