### PR TITLE
Rename “sliceData” option to “slice”

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ For details on how each kind of chart is rendered, take a look at [`charts.js`](
 |---|---|---|
 | `series` | array of strings | only include these data series and drop all others (referenced by TSV table headings) |
 | `visibleSeries` | array of strings | only show the listed data series and hide all others initially (referenced by TSV table headings) |
-| `sliceData` | array `[t0, t1]` | slice the data from the TSV file as if `data.slice(t0, t1)` was called |
+| `slice` | array `[t0, t1]` | slice the data from the TSV file as if `data.slice(t0, t1)` was called |
 | `aggregate` | dictionary (see below) | defines how data should be aggregated (default: `undefined`, which leaves the data untouched) |
 | `aggregate.period` | `week`, `month` | specifies the range over which the data shall be aggregated |
 | `aggregate.method` | `sum`, `mean`, `min`, `max`, `first`, `last`, `median` | specifies the aggregation method; `first` and `last` select the chronologically first or last data point present in each period, respectively |

--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -274,8 +274,8 @@ function createHistoryChart(canvas)
 
             const context = canvas.getContext('2d');
 
-            if (hasConfig($(canvas), 'sliceData'))
-                data = data.slice(readConfig($(canvas), 'sliceData')[0], readConfig($(canvas), 'sliceData')[1]);
+            if (hasConfig($(canvas), 'slice'))
+                data = data.slice(readConfig($(canvas), 'slice')[0], readConfig($(canvas), 'slice')[1]);
 
             if (hasConfig($(canvas), 'aggregate'))
                 data = aggregateTimeData(data, $(canvas).data('config').aggregate);
@@ -363,8 +363,8 @@ function createList(canvas)
 
             const context = canvas.getContext('2d');
 
-            if (hasConfig($(canvas), 'sliceData'))
-                data = data.slice(readConfig($(canvas), 'sliceData')[0], readConfig($(canvas), 'sliceData')[1]);
+            if (hasConfig($(canvas), 'slice'))
+                data = data.slice(readConfig($(canvas), 'slice')[0], readConfig($(canvas), 'slice')[1]);
 
             const types = hasConfig($(canvas), 'series')
                 ? readConfig($(canvas), 'series')

--- a/docs/pr-total.html
+++ b/docs/pr-total.html
@@ -42,7 +42,7 @@ permalink: /pr-total
 			"visibleSeries": [
 				"merged"
 			],
-			"sliceData": [
+			"slice": [
 				0,
 				20
 			]
@@ -68,7 +68,7 @@ permalink: /pr-total
 			"visibleSeries": [
 				"merged"
 			],
-			"sliceData": [
+			"slice": [
 				0,
 				20
 			]

--- a/docs/users-contributors.html
+++ b/docs/users-contributors.html
@@ -9,7 +9,7 @@ permalink: /users-contributors
 	<canvas
 		data-url="{{ site.dataURL }}/contributors-by-repository.tsv"
 		data-type="list"
-		data-config='{"sliceData": [0, 20]}'
+		data-config='{"slice": [0, 20]}'
 	></canvas>
 	<div class="info-box">
 		<p>
@@ -23,7 +23,7 @@ permalink: /users-contributors
 	<canvas
 		data-url="{{ site.dataURL }}/contributors-by-organization.tsv"
 		data-type="list"
-		data-config='{"sliceData": [0, 20]}'
+		data-config='{"slice": [0, 20]}'
 	></canvas>
 	<div class="info-box">
 		<p>


### PR DESCRIPTION
For consitency with the `aggregate` option, this renames the `sliceData` option to simply `slice`.