### PR TITLE
Move helper functions to separate module

### DIFF
--- a/updater/helpers.py
+++ b/updater/helpers.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 import sys
 
+from config import *
+
 # Simple class to get floating-point values printed prettily
 class PrettyFloat(float):
 	def __str__(self):
@@ -24,3 +26,23 @@ def executeCommand(command, stdin = None, cwd = None):
 # Convenience function to parse a date from a string
 def parseDate(string):
 	return datetime.datetime.strptime(string, "%Y-%m-%d").date()
+
+# The location of the local working copy of the data repository
+def locateDataDirectory():
+	tmpDirectory = configuration["tmpDirectory"]
+	return os.path.join(tmpDirectory, "hubble-data")
+
+# Create a local clone of the data repository if not present and update it
+def prepareDataDirectory(dataDirectory, fetchChanges = True):
+	# Create data directory if not existing
+	if not os.path.exists(dataDirectory):
+		os.makedirs(dataDirectory)
+
+	# Get the data directory up-to-date
+	if fetchChanges:
+		# Clone data repository if necessary
+		if not os.path.exists(os.path.join(dataDirectory, ".git")):
+			executeCommand(["git", "clone", configuration["repositoryURL"], "."], cwd = dataDirectory)
+		else:
+			executeCommand(["git", "fetch"], cwd = dataDirectory)
+			executeCommand(["git", "reset", "--hard", "origin/master"], cwd = dataDirectory)

--- a/updater/helpers.py
+++ b/updater/helpers.py
@@ -1,0 +1,26 @@
+import datetime
+import os
+import subprocess
+import sys
+
+# Simple class to get floating-point values printed prettily
+class PrettyFloat(float):
+	def __str__(self):
+		return "%0.3f" % self
+
+# Executes a single command and returns stdout and stderr
+def executeCommand(command, stdin = None, cwd = None):
+	with subprocess.Popen(command, stdout = subprocess.PIPE, stderr = subprocess.PIPE, stdin = (subprocess.PIPE if stdin != None else None), cwd = cwd) as process:
+		stdout, stderr = process.communicate(input = (stdin.encode("utf-8") if stdin != None else None))
+
+		print(stderr.decode("utf-8"), file = sys.stderr)
+		sys.stderr.flush()
+
+		if process.returncode != 0:
+			raise RuntimeError(command[0] + " failed with exit code " + str(process.returncode))
+
+		return stdout, stderr
+
+# Convenience function to parse a date from a string
+def parseDate(string):
+	return datetime.datetime.strptime(string, "%Y-%m-%d").date()

--- a/updater/reports/Report.py
+++ b/updater/reports/Report.py
@@ -2,31 +2,10 @@ import csv
 import datetime
 import io
 import os
-import subprocess
 import sys
 import time
 
-# Simple class to get floating-point values printed prettily
-class PrettyFloat(float):
-	def __str__(self):
-		return "%0.3f" % self
-
-# Executes a single command and returns stdout and stderr
-def executeCommand(command, stdin = None, cwd = None):
-	with subprocess.Popen(command, stdout = subprocess.PIPE, stderr = subprocess.PIPE, stdin = (subprocess.PIPE if stdin != None else None), cwd = cwd) as process:
-		stdout, stderr = process.communicate(input = (stdin.encode("utf-8") if stdin != None else None))
-
-		print(stderr.decode("utf-8"), file = sys.stderr)
-		sys.stderr.flush()
-
-		if process.returncode != 0:
-			raise RuntimeError(command[0] + " failed with exit code " + str(process.returncode))
-
-		return stdout, stderr
-
-# Convenience function to parse a date from a string
-def parseDate(string):
-	return datetime.datetime.strptime(string, "%Y-%m-%d").date()
+from helpers import *
 
 # Abstract base class for all reports that automates reading and writing reports etc.
 class Report(object):

--- a/updater/update-stats.py
+++ b/updater/update-stats.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 
 from config import *
+from helpers import *
 
 from reports.ReportAPIRequests import *
 from reports.ReportContributorsByOrg import *
@@ -59,22 +60,9 @@ def main():
 	print("Preparing update of GitHub usage statistics", file = sys.stderr)
 	sys.stderr.flush()
 
-	localRepositoryName = "hubble-data"
-	tmpDirectory = configuration["tmpDirectory"]
-	dataDirectory = os.path.join(tmpDirectory, localRepositoryName)
-
-	# Create data directory if not existing
-	if not os.path.exists(dataDirectory):
-		os.makedirs(dataDirectory)
-
-	# Get the data directory up-to-date
-	if not configuration["dryRun"]:
-		# Clone data repository if necessary
-		if not os.path.exists(os.path.join(dataDirectory, ".git")):
-			executeCommand(["git", "clone", configuration["repositoryURL"], "."], cwd = dataDirectory)
-		else:
-			executeCommand(["git", "fetch"], cwd = dataDirectory)
-			executeCommand(["git", "reset", "--hard", "origin/master"], cwd = dataDirectory)
+	# Prepare the data directory for writing the new data
+	dataDirectory = locateDataDirectory()
+	prepareDataDirectory(dataDirectory, fetchChanges = not configuration["dryRun"])
 
 	configuration["today"] = datetime.date.today()
 


### PR DESCRIPTION
I want to add a data repository scheme check to Hubble, which will share the data repository preparation steps with `update-stats.py`. For this reason, I thought it would be best to move these steps into a new helper module (see db13f474d9678957e6ed7d7ab46feedac4b778ce) so that they can be reused later on.

At the same time, I remembered that the `Report` module contained multiple helpers that don’t really belong there. For this reason, I moved them into the helper module as well (see c83d974f2e88598b506a67065f38af36085ed221).

I tested the changes and verified that everything works just as before.