### PR TITLE
Add forward compatibility check to updater

### DIFF
--- a/updater/check-schema.py
+++ b/updater/check-schema.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import sys
+
+from schema import *
+
+if __name__ == "__main__":
+	# Prepare the data directory for writing the new data
+	dataDirectory = locateDataDirectory()
+	prepareDataDirectory(dataDirectory, fetchChanges = not configuration["dryRun"])
+
+	# Verify schema version for forward compatibility
+	checkSchemaVersion(dataDirectory)
+
+	print("info: the data repository scheme is up-to-date", file = sys.stderr)

--- a/updater/schema.py
+++ b/updater/schema.py
@@ -1,0 +1,28 @@
+import csv
+import os
+import sys
+
+from config import *
+from helpers import *
+
+schemaVersion = 1
+
+# Check the data repository's schema version and fail if it's outdated
+# Assumes that the data directory is already initialized and up-to-date
+def checkSchemaVersion(dataDirectory):
+	schemaVersionLocal = 0
+
+	try:
+		with open(os.path.join(dataDirectory, "meta.tsv"), "r") as tsvFile:
+			tsvReader = csv.reader(tsvFile, delimiter = "\t")
+
+			for row in tsvReader:
+				if row[0] == "schema-version":
+					schemaVersionLocal = int(row[1])
+					break
+	except:
+		pass
+
+	if schemaVersionLocal < schemaVersion:
+		print("error: the data repository has an outdated scheme and needs to be migrated", file = sys.stderr)
+		sys.exit(1)

--- a/updater/update-stats.py
+++ b/updater/update-stats.py
@@ -6,6 +6,7 @@ import sys
 
 from config import *
 from helpers import *
+from schema import *
 
 from reports.ReportAPIRequests import *
 from reports.ReportContributorsByOrg import *
@@ -36,7 +37,7 @@ def writeMeta(dataDirectory):
 
 	with open(outputFilePath, "w") as outputFile:
 		outputFile.write("key\tvalue\n")
-		outputFile.write("schema-version\t1\n")
+		outputFile.write("schema-version\t" + str(schemaVersion) + "\n")
 
 def writeMetaStats(metaStats, dataDirectory):
 	outputFilePath = os.path.join(dataDirectory, "meta-runtimes.tsv")
@@ -63,6 +64,9 @@ def main():
 	# Prepare the data directory for writing the new data
 	dataDirectory = locateDataDirectory()
 	prepareDataDirectory(dataDirectory, fetchChanges = not configuration["dryRun"])
+
+	# Verify schema version for forward compatibility
+	checkSchemaVersion(dataDirectory)
 
 	configuration["today"] = datetime.date.today()
 


### PR DESCRIPTION
With this addition, the updater checks the schema version of the data in the data repository before attempting to run. In the case that the schema is outdated, an error is returned indicating that a migration
needs to be performed manually.

Additionally, the new script `check-schema.py` can be manually invoked to check the data schema prior to actually running the updater.