### PR TITLE
list of active repositories (refactored)

### DIFF
--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -538,10 +538,15 @@ function createTable(table)
                 .append('th')
                 .text(d => d);
 
+            let displayData = data;
+            const configSlice = readConfig($(table), 'slice');
+            if (Array.isArray(configSlice) && configSlice.length > 1)
+                displayData = data.slice(configSlice[0], configSlice[1]);
+
             let rows = d3.select(table)
                 .append('tbody')
                 .selectAll('tr')
-                .data(data)
+                .data(displayData)
                 .enter()
                 .append('tr');
 

--- a/docs/demo-data/repository-activity-detailed.tsv
+++ b/docs/demo-data/repository-activity-detailed.tsv
@@ -1,0 +1,4 @@
+repository	pushers	pushes
+some/repo	2	42
+other/repo	3	36
+last/repo	1	12

--- a/docs/repos-activity.html
+++ b/docs/repos-activity.html
@@ -33,6 +33,17 @@ permalink: /repos-activity
 </div>
 
 <div class="chart-placeholder">
+	<h3>Most Active Repositories</h3>
+	<table
+		data-url="{{ site.dataURL }}/repository-activity-detailed.tsv"
+		data-config='{"slice": [0, 50]}'
+	></table>
+	<div class="info-box">
+		<p>The top 50 most active repositories by number of pushes.</p>
+	</div>
+</div>
+
+<div class="chart-placeholder">
 	<h3>Active Repositories in User Accounts</h3>
 	<canvas
 		data-url="{{ site.dataURL }}/repository-activity.tsv"

--- a/updater/reports/ReportRepoActivity.py
+++ b/updater/reports/ReportRepoActivity.py
@@ -17,6 +17,9 @@ class ReportRepoActivity(ReportDaily):
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()
+		self.detailedHeader, self.detailedData = self.parseData(
+			self.executeQuery(self.detailedQuery())
+		)
 
 	# Collects active repositories for a user type (user/organization)
 	# given a time range
@@ -80,4 +83,18 @@ class ReportRepoActivity(ReportDaily):
 				(''' + self.countActiveRepos("User", [oneDayAgo, oneDayAgo]) + ''') AS userSpaceLastDay
 			'''
 
+		return query
+
+	# Collects the active organizational repositories over the last 4 weeks
+	def detailedQuery(self):
+		oneDayAgo = self.yesterday()
+		fourWeeksAgo = self.daysAgo(28)
+		query = '''
+			SELECT
+				repository,
+				pusher_count as "pushers",
+				push_count as "pushes"
+			FROM (''' + self.activeRepos("Organization", [fourWeeksAgo, oneDayAgo]) + ''') AS activeRepos
+			ORDER BY push_count DESC
+		'''
 		return query


### PR DESCRIPTION
Based on @mlbright 's work in #119 I did the following:
- move the "active repos table" into the "active repos section" (I know we discussed that before and I think I asked you to move it to the "repo usage" section ... no idea why I said that ... that was stupid of me)
- display pusher count and push count
- display repository `org/repo` to make the auto linking to GHE work
- added demo data
- squashed commits

@mlbright please review!