### PR TITLE
Don’t jump to top of the page when switching views

### DIFF
--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -401,6 +401,8 @@ function createHistoryChart(canvas, actionBar)
                     // Trigger a Chart.js update
                     $(canvas).data('chart').update();
                     $(this).addClass('active');
+
+                    return false;
                 });
         }
     ).on('load.spinner', function()
@@ -920,6 +922,8 @@ function createChordChart(canvas, actionBar)
                     // Trigger an update
                     update();
                     $(this).addClass('active');
+
+                    return false;
                 });
 
             switchToView(defaultView);


### PR DESCRIPTION
Clicks on the view switcher buttons are supposed to be handled by JavaScript in order to switch the active view, bypassing the browser. However, without telling the browser that the click events have been reacted to, it will load the URL as usual. As the view switcher buttons have a `#` placeholder link, this would cause the browser to jump to to the top of the page.

This is fixed by returning `false` in the click event handling functions.