### PR TITLE
Enable multiple views on all history charts

### DIFF
--- a/docs/housekeeping-abandoned-orgs.html
+++ b/docs/housekeeping-abandoned-orgs.html
@@ -9,7 +9,37 @@ permalink: /housekeeping-abandoned-orgs
 	<canvas
 		data-url="{{ site.dataURL }}/organizations-abandoned.tsv"
 		data-type="history"
-	></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			An organizations is considered <em>abandoned</em> if none of its repositories has received a push in the last year (ignoring <a href="https://help.github.com/articles/archiving-repositories/">archived</a> repositories).

--- a/docs/housekeeping-api-requests.html
+++ b/docs/housekeeping-api-requests.html
@@ -9,7 +9,37 @@ permalink: /housekeeping-api-requests
 	<canvas
 		data-url="{{ site.dataURL }}/api-requests.tsv"
 		data-type="history"
-	></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			The total number of <a href="https://developer.github.com/">GitHub API requests</a>.

--- a/docs/housekeeping-forks.html
+++ b/docs/housekeeping-forks.html
@@ -9,7 +9,37 @@ permalink: /housekeeping-forks
 	<canvas
 		data-url="{{ site.dataURL }}/forks-to-organizations.tsv"
 		data-type="history"
-	></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			Forks to personal user accounts are a great way to contribute code.

--- a/docs/housekeeping-git-requests.html
+++ b/docs/housekeeping-git-requests.html
@@ -9,7 +9,37 @@ permalink: /housekeeping-git-requests
 	<canvas
 		data-url="{{ site.dataURL }}/git-requests.tsv"
 		data-type="history"
-	></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			The total number of Git requests (includes pushes, fetches, and clones).

--- a/docs/housekeeping-git-traffic.html
+++ b/docs/housekeeping-git-traffic.html
@@ -10,12 +10,51 @@ permalink: /housekeeping-git-traffic
 		data-url="{{ site.dataURL }}/git-download.tsv"
 		data-type="history"
 		data-config='{
-			"series": [
-				"clones/day",
-				"fetches/day"
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"series":
+					[
+						"clones/day",
+						"fetches/day"
+					],
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					},
+					"series":
+					[
+						"clones/day",
+						"fetches/day"
+					],
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					},
+					"series":
+					[
+						"clones/day",
+						"fetches/day"
+					]
+				}
 			]
-		}'
-	></canvas>
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			<em>Cloning</em> a Git repository is expensive, as the entire repository history must be transferred.
@@ -34,12 +73,51 @@ permalink: /housekeeping-git-traffic
 		data-url="{{ site.dataURL }}/git-download.tsv"
 		data-type="history"
 		data-config='{
-			"series": [
-				"clone traffic/day [GB]",
-				"fetch traffic/day [GB]"
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"series":
+					[
+						"clone traffic/day [GB]",
+						"fetch traffic/day [GB]"
+					],
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					},
+					"series":
+					[
+						"clone traffic/day [GB]",
+						"fetch traffic/day [GB]"
+					],
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					},
+					"series":
+					[
+						"clone traffic/day [GB]",
+						"fetch traffic/day [GB]"
+					]
+				}
 			]
-		}'
-	></canvas>
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			The amount of data transferred for clones and fetches.

--- a/docs/housekeeping-repo-location.html
+++ b/docs/housekeeping-repo-location.html
@@ -9,7 +9,37 @@ permalink: /housekeeping-repo-location
 	<canvas
 		data-url="{{ site.dataURL }}/repositories-personal-nonowner-pushes.tsv"
 		data-type="history"
-	></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			Repositories in user accounts should only be pushed to by their owners, as these repositories might become unavailable or deleted if the owner leaves the company.

--- a/docs/orgs-activity.html
+++ b/docs/orgs-activity.html
@@ -10,16 +10,66 @@ permalink: /orgs-activity
 		data-url="{{ site.dataURL }}/organization-activity.tsv"
 		data-type="history"
 		data-config='{
-			"series": [
-				"last four weeks",
-				"last week",
-				"last day"
-			],
-			"visibleSeries": [
-				"last four weeks"
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"series":
+					[
+						"last four weeks",
+						"last week",
+						"last day"
+					],
+					"visibleSeries":
+					[
+						"last four weeks"
+					],
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"last four weeks",
+						"last week",
+						"last day"
+					],
+					"visibleSeries":
+					[
+						"last four weeks"
+					],
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"last four weeks",
+						"last week",
+						"last day"
+					],
+					"visibleSeries":
+					[
+						"last four weeks"
+					]
+				}
 			]
-		}'
-		></canvas>
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			Shows how many organizations are active.

--- a/docs/orgs-total.html
+++ b/docs/orgs-total.html
@@ -9,7 +9,37 @@ permalink: /orgs-total
 	<canvas
 		data-url="{{ site.dataURL }}/orgs-total.tsv"
 		data-type="history"
-		></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			The number of organizations in total.

--- a/docs/pr-usage.html
+++ b/docs/pr-usage.html
@@ -9,8 +9,37 @@ permalink: /pr-usage
 	<canvas
 		data-url="{{ site.dataURL }}/pull-request-usage.tsv"
 		data-type="history"
-		data-config='{"aggregate": {"period": "month", "method": "first"}}'
-	></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			The percentage of active repositories located in organizations, having more than one contributor, and using pull requests for contributions.

--- a/docs/recommendations-legacy-teams.html
+++ b/docs/recommendations-legacy-teams.html
@@ -9,7 +9,37 @@ permalink: /recommendations-legacy-teams
 	<canvas
 		data-url="{{ site.dataURL }}/teams-legacy.tsv"
 		data-type="history"
-	></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			Organizations created before September 2015 might have legacy admin teams.

--- a/docs/recommendations-tokenless-auth.html
+++ b/docs/recommendations-tokenless-auth.html
@@ -9,7 +9,37 @@ permalink: /recommendations-tokenless-auth
 	<canvas
 		data-url="{{ site.dataURL }}/tokenless-authentication.tsv"
 		data-type="history"
-	></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			If your GitHub Enterprise appliance is configured to use <a href="https://help.github.com/enterprise/2.11/admin/guides/user-management/using-ldap/">LDAP authentication</a>, then every request against GitHub requires an additional request against LDAP.

--- a/docs/repos-activity.html
+++ b/docs/repos-activity.html
@@ -10,13 +10,64 @@ permalink: /repos-activity
 		data-url="{{ site.dataURL }}/repository-activity.tsv"
 		data-type="history"
 		data-config='{
-			"series": [
-				"in organizations (last four weeks)",
-				"in organizations (last week)",
-				"in organizations (last day)"
-			],
-			"visibleSeries": [
-				"in organizations (last four weeks)"
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"series":
+					[
+						"in organizations (last four weeks)",
+						"in organizations (last week)",
+						"in organizations (last day)"
+					],
+					"visibleSeries":
+					[
+						"in organizations (last four weeks)"
+					],
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"in organizations (last four weeks)",
+						"in organizations (last week)",
+						"in organizations (last day)"
+					],
+					"visibleSeries":
+					[
+						"in organizations (last four weeks)"
+					],
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"in organizations (last four weeks)",
+						"in organizations (last week)",
+						"in organizations (last day)"
+					],
+					"visibleSeries":
+					[
+						"in organizations (last four weeks)"
+					]
+				}
 			]
 		}'
 		></canvas>
@@ -49,16 +100,66 @@ permalink: /repos-activity
 		data-url="{{ site.dataURL }}/repository-activity.tsv"
 		data-type="history"
 		data-config='{
-			"series": [
-				"in user accounts (last four weeks)",
-				"in user accounts (last week)",
-				"in user accounts (last day)"
-			],
-			"visibleSeries": [
-				"in user accounts (last four weeks)"
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"series":
+					[
+						"in user accounts (last four weeks)",
+						"in user accounts (last week)",
+						"in user accounts (last day)"
+					],
+					"visibleSeries":
+					[
+						"in user accounts (last four weeks)"
+					],
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"in user accounts (last four weeks)",
+						"in user accounts (last week)",
+						"in user accounts (last day)"
+					],
+					"visibleSeries":
+					[
+						"in user accounts (last four weeks)"
+					],
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"in user accounts (last four weeks)",
+						"in user accounts (last week)",
+						"in user accounts (last day)"
+					],
+					"visibleSeries":
+					[
+						"in user accounts (last four weeks)"
+					]
+				}
 			]
-		}'
-		></canvas>
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			Shows how many repositories are active in user accounts.

--- a/docs/repos-feature-usage.html
+++ b/docs/repos-feature-usage.html
@@ -9,7 +9,37 @@ permalink: /repos-feature-usage
 	<canvas
 		data-url="{{ site.dataURL }}/repository-usage.tsv"
 		data-type="history"
-		></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			The percentage of active repositories located in organizations with at least one active <a href="https://help.github.com/articles/about-protected-branches/">protected branch</a> and at least one <a href="https://help.github.com/articles/about-topics/">topic</a> assigned to them.

--- a/docs/repos-total.html
+++ b/docs/repos-total.html
@@ -10,16 +10,66 @@ permalink: /repos-total
 		data-url="{{ site.dataURL }}/repository-history.tsv"
 		data-type="history"
 		data-config='{
-			"series": [
-				"in organizations",
-				"in user accounts",
-				"total"
-			],
-			"visibleSeries": [
-				"in organizations"
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"series":
+					[
+						"in organizations",
+						"in user accounts",
+						"total"
+					],
+					"visibleSeries":
+					[
+						"in organizations"
+					],
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"in organizations",
+						"in user accounts",
+						"total"
+					],
+					"visibleSeries":
+					[
+						"in organizations"
+					],
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"in organizations",
+						"in user accounts",
+						"total"
+					],
+					"visibleSeries":
+					[
+						"in organizations"
+					]
+				}
 			]
-		}'
-		></canvas>
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			The number of repositories in organizations, in user accounts, and in total.

--- a/docs/teams-total.html
+++ b/docs/teams-total.html
@@ -9,7 +9,37 @@ permalink: /teams-total
 	<canvas
 		data-url="{{ site.dataURL }}/teams-total.tsv"
 		data-type="history"
-		></canvas>
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					}
+				}
+			]
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			The number of teams in total.

--- a/docs/users-activity.html
+++ b/docs/users-activity.html
@@ -10,18 +10,72 @@ permalink: /users-activity
 		data-url="{{ site.dataURL }}/users.tsv"
 		data-type="history"
 		data-config='{
-			"series": [
-				"using license",
-				"pushing commits (last month)",
-				"pushing commits (last week)",
-				"pushing commits (last day)"
-			],
-			"visibleSeries": [
-				"using license",
-				"pushing commits (last month)"
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"series":
+					[
+						"using license",
+						"pushing commits (last month)",
+						"pushing commits (last week)",
+						"pushing commits (last day)"
+					],
+					"visibleSeries":
+					[
+						"using license",
+						"pushing commits (last month)"
+					],
+					"slice": [0, 61]
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"using license",
+						"pushing commits (last month)",
+						"pushing commits (last week)",
+						"pushing commits (last day)"
+					],
+					"visibleSeries":
+					[
+						"using license",
+						"pushing commits (last month)"
+					],
+					"slice": [0, 106],
+					"default": true
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "first"
+					},
+					"series":
+					[
+						"using license",
+						"pushing commits (last month)",
+						"pushing commits (last week)",
+						"pushing commits (last day)"
+					],
+					"visibleSeries":
+					[
+						"using license",
+						"pushing commits (last month)"
+					]
+				}
 			]
-		}'
-	></canvas>
+		}'></canvas>
 	<div class="info-box">
 		<p>
 			<i>Using license</i> shows how many GitHub Enterprise licenses were used at a given date.


### PR DESCRIPTION
This makes all remaining history charts multiview-capable. For most charts, it made sense to select one value of each time period for weekly aggregation, while for a few others, computing the sum was more apt.

I know that the configuration is kind of clunky. However, I’d like to keep it like this for some time until we have an intuition of whether we should make some of these configuration values defaults or not.