### PR TITLE
Remove the “/day” suffix from data series labels

### DIFF
--- a/docs/demo-data/api-requests-detailed.tsv
+++ b/docs/demo-data/api-requests-detailed.tsv
@@ -1,4 +1,4 @@
-resource	type	source IP	requests/day
+resource	type	source IP	requests
 foo/bar	repos	10.11.12.13	35498
 some/code	repos	10.21.11.33	27384
 some/other-code	repos	10.21.11.33	24212

--- a/docs/demo-data/api-requests.tsv
+++ b/docs/demo-data/api-requests.tsv
@@ -1,4 +1,4 @@
-date	API requests/day
+date	API requests
 2017-10-04	1010655
 2017-10-03	1099659
 2017-10-02	1295868

--- a/docs/demo-data/git-download-detailed.tsv
+++ b/docs/demo-data/git-download-detailed.tsv
@@ -1,4 +1,4 @@
-repository	user	cloning?	requests/day	download/day [GB]
+repository	user	cloning?	requests	download [GB]
 someOrg512/repo131	someUser5322	true	7	67
 someOrg708/repo891	someUser5337	true	44	36
 someOrg708/repo806	someUser276	true	40	34

--- a/docs/demo-data/git-download.tsv
+++ b/docs/demo-data/git-download.tsv
@@ -1,4 +1,4 @@
-date	clones/day	fetches/day	clone traffic/day [GB]	fetch traffic/day [GB]
+date	clones	fetches	clone traffic [GB]	fetch traffic [GB]
 2017-10-04	17272	22348	672	25
 2017-10-03	18067	21223	587	28
 2017-10-02	15605	20744	502	20

--- a/docs/demo-data/git-requests-detailed.tsv
+++ b/docs/demo-data/git-requests-detailed.tsv
@@ -1,4 +1,4 @@
-repository	source IP	requests/day
+repository	source IP	requests
 org/repo	12.13.14.15	31050
 foo/bar	10.11.87.145	27446
 some/thing	10.11.87.145	22527

--- a/docs/demo-data/git-requests.tsv
+++ b/docs/demo-data/git-requests.tsv
@@ -1,4 +1,4 @@
-date	Git requests/day
+date	Git requests
 2017-10-04	2617732
 2017-10-03	2506574
 2017-10-02	2556201

--- a/docs/demo-data/tokenless-authentication-detailed.tsv
+++ b/docs/demo-data/tokenless-authentication-detailed.tsv
@@ -1,3 +1,3 @@
-user	repository	tokenless authentications/day
+user	repository	tokenless authentications
 larsxschneider	foo/bar	5104
 service-bot	some/repo	5081

--- a/docs/demo-data/tokenless-authentication.tsv
+++ b/docs/demo-data/tokenless-authentication.tsv
@@ -1,4 +1,4 @@
-date	tokenless authentications/day
+date	tokenless authentications
 2017-10-04	344312
 2017-10-03	331129
 2017-10-02	348062

--- a/docs/housekeeping-git-traffic.html
+++ b/docs/housekeeping-git-traffic.html
@@ -18,8 +18,8 @@ permalink: /housekeeping-git-traffic
 					"aggregate": false,
 					"series":
 					[
-						"clones/day",
-						"fetches/day"
+						"clones",
+						"fetches"
 					],
 					"slice": [0, 61]
 				},
@@ -33,8 +33,8 @@ permalink: /housekeeping-git-traffic
 					},
 					"series":
 					[
-						"clones/day",
-						"fetches/day"
+						"clones",
+						"fetches"
 					],
 					"slice": [0, 106],
 					"default": true
@@ -49,8 +49,8 @@ permalink: /housekeeping-git-traffic
 					},
 					"series":
 					[
-						"clones/day",
-						"fetches/day"
+						"clones",
+						"fetches"
 					]
 				}
 			]
@@ -81,8 +81,8 @@ permalink: /housekeeping-git-traffic
 					"aggregate": false,
 					"series":
 					[
-						"clone traffic/day [GB]",
-						"fetch traffic/day [GB]"
+						"clone traffic [GB]",
+						"fetch traffic [GB]"
 					],
 					"slice": [0, 61]
 				},
@@ -96,8 +96,8 @@ permalink: /housekeeping-git-traffic
 					},
 					"series":
 					[
-						"clone traffic/day [GB]",
-						"fetch traffic/day [GB]"
+						"clone traffic [GB]",
+						"fetch traffic [GB]"
 					],
 					"slice": [0, 106],
 					"default": true
@@ -112,8 +112,8 @@ permalink: /housekeeping-git-traffic
 					},
 					"series":
 					[
-						"clone traffic/day [GB]",
-						"fetch traffic/day [GB]"
+						"clone traffic [GB]",
+						"fetch traffic [GB]"
 					]
 				}
 			]

--- a/updater/reports/ReportAPIRequests.py
+++ b/updater/reports/ReportAPIRequests.py
@@ -10,7 +10,7 @@ class ReportAPIRequests(ReportDaily):
 			self.executeScript(self.scriptPath("api-requests.sh"))
 		)
 		if len(self.data) == 0:
-			self.header = ["date", "API requests/day"]
+			self.header = ["date", "API requests"]
 		self.data.append(
 			[str(self.yesterday()),
 			sum(map(lambda x: int(x[3] if len(x) > 2 else 0), newData))]

--- a/updater/reports/ReportGitDownload.py
+++ b/updater/reports/ReportGitDownload.py
@@ -12,10 +12,10 @@ class ReportGitDownload(ReportDaily):
 		if len(self.data) == 0:
 			self.header = [
 				"date",
-				"clones/day",
-				"fetches/day",
-				"clone traffic/day [GB]",
-				"fetch traffic/day [GB]",
+				"clones",
+				"fetches",
+				"clone traffic [GB]",
+				"fetch traffic [GB]",
 			]
 		self.data.append([
 			str(self.yesterday()),
@@ -24,7 +24,7 @@ class ReportGitDownload(ReportDaily):
 			sum(map(lambda x: int(x[4] if len(x) > 3 and x[2] == "true" else 0), newData))//(1024**3),
 			sum(map(lambda x: int(x[4] if len(x) > 3 and x[2] != "true" else 0), newData))//(1024**3),
 		])
-		self.detailedHeader[4] = "download/day [GB]"
+		self.detailedHeader[4] = "download [GB]"
 		self.detailedData = map(lambda x: [x[0], x[1], x[2], x[3], round(int(x[4])/(1024**3))], newData[:25])
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportGitRequests.py
+++ b/updater/reports/ReportGitRequests.py
@@ -10,7 +10,7 @@ class ReportGitRequests(ReportDaily):
 			self.executeScript(self.scriptPath("git-requests.sh"))
 		)
 		if len(self.data) == 0:
-			self.header = ["date", "Git requests/day"]
+			self.header = ["date", "Git requests"]
 		self.data.append(
 			[str(self.yesterday()),
 			sum(map(lambda x: int(x[2] if len(x) > 1 else 0), newData))]

--- a/updater/reports/ReportTokenlessAuth.py
+++ b/updater/reports/ReportTokenlessAuth.py
@@ -10,7 +10,7 @@ class ReportTokenlessAuth(ReportDaily):
 			self.executeScript(self.scriptPath("tokenless-auth.sh"))
 		)
 		if len(self.data) == 0:
-			self.header = ["date", "tokenless authentications/day"]
+			self.header = ["date", "tokenless authentications"]
 		self.data.append(
 			[str(self.yesterday()),
 			sum(map(lambda x: int(x[2] if len(x) > 1 else 0), newData))]

--- a/updater/scripts/api-requests.sh
+++ b/updater/scripts/api-requests.sh
@@ -2,7 +2,7 @@
 #
 # Count number of API calls per type and user/org/repo (resource)
 #
-echo -e "resource\ttype\tsource IP\trequests/day"
+echo -e "resource\ttype\tsource IP\trequests"
 
 zcat -f /var/log/haproxy.log.1* |
     perl -ne 'print if s/.*haproxy\[\d+\]: ([^:]+).*\/api\/v3\/([^\/\? ]+)\/([^\/\? ]+?(\/[^\/\? ]+)).*/\1 \2 \3/' |

--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -59,7 +59,7 @@ else
         '/\1\t\2\t\3\t\4/'
 fi
 
-echo -e "repository\tuser\tcloning?\trequests/day\tdownload/day [B]"
+echo -e "repository\tuser\tcloning?\trequests\tdownload [B]"
 
 eval "$CAT_LOG_FILE" |
     perl -ne "$EXTRACT_FIELDS" |

--- a/updater/scripts/git-requests.sh
+++ b/updater/scripts/git-requests.sh
@@ -2,7 +2,7 @@
 #
 # Count number of Git repository requests per day
 #
-echo -e "repository\tsource IP\trequests/day"
+echo -e "repository\tsource IP\trequests"
 
 zcat -f /var/log/babeld/babeld.log.1* |
     perl -ne 'print if s/.*ip=([^ ]+).*repo=([^ ]+).*/\1 \2/' |

--- a/updater/scripts/tokenless-auth.sh
+++ b/updater/scripts/tokenless-auth.sh
@@ -3,7 +3,7 @@
 # Lists users that make the most requests with username/password
 # c.f. https://help.github.com/enterprise/2.11/admin/guides/user-management/using-ldap/#disabling-password-authentication-for-git-operations
 #
-echo -e "user\trepository\ttokenless authentications/day"
+echo -e "user\trepository\ttokenless authentications"
 
 zcat -f /var/log/github/gitauth.log.1* |
     perl -ne 'print if s/.*status=OK member="?([^ "]+) hashed_token=nil.*path=([^ ]+)\.git .*proto=http.*/\1 \2/' |


### PR DESCRIPTION
With the recent addition of multiple views with aggregated data, the `/day` label suffix doesn’t make sense in cases where weekly data is actually shown.

This removes the suffix from all labels to avoid confusion.

Note that Hubble will apply the header change upon the next run after applying the update. This means that between the time of applying the update and running Hubble, the web frontend will show empty charts, because the data series labels won’t match. However, I think that this is an acceptable caveat.