### PR TITLE
Fix error with empty chart views

### DIFF
--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -256,6 +256,9 @@ function aggregateTimeData(data, aggregationConfig)
 
 function buildHistoryChartData(view)
 {
+    if (view.data.length == 0)
+        return Array();
+
     const originalDataSeries = Object.keys(view.data[0]).slice(1);
     const dataSeries = 'series' in view ? view.series : originalDataSeries;
     const visibleDataSeries = 'visibleSeries' in view ? view.visibleSeries : originalDataSeries;


### PR DESCRIPTION
When aggregating over only few data points, the weekly-aggregated views might end up empty. This led to an error, because the chart generation relied on the data not to be empty.

This adds a corresponding check, which prevents the error and shows an empty chart as expected.

Instead of showing users empty charts, views with no data should be hidden from the users. This will be addressed separately (tracked in issue #133).

Note that with the meek amounts of demo data that we currently have, many chart views in the [interactive demo](https://autodesk.github.io/hubble/) end up empty. This should be addressed as suggested in #132.

Fixes #128.