### PR TITLE
Switch user activity chart to 4-week intervals

### DIFF
--- a/docs/demo-data/users.tsv
+++ b/docs/demo-data/users.tsv
@@ -1,4 +1,4 @@
-date	pushing commits (last day)	pushing commits (last week)	pushing commits (last month)	using license
+date	pushing commits (last day)	pushing commits (last week)	pushing commits (last four weeks)	using license
 2017-09-25	104	184	235	330
 2017-09-24	13	182	234	326
 2017-09-23	12	181	238	325

--- a/docs/users-activity.html
+++ b/docs/users-activity.html
@@ -19,14 +19,14 @@ permalink: /users-activity
 					"series":
 					[
 						"using license",
-						"pushing commits (last month)",
+						"pushing commits (last four weeks)",
 						"pushing commits (last week)",
 						"pushing commits (last day)"
 					],
 					"visibleSeries":
 					[
 						"using license",
-						"pushing commits (last month)"
+						"pushing commits (last four weeks)"
 					],
 					"slice": [0, 61]
 				},
@@ -41,14 +41,14 @@ permalink: /users-activity
 					"series":
 					[
 						"using license",
-						"pushing commits (last month)",
+						"pushing commits (last four weeks)",
 						"pushing commits (last week)",
 						"pushing commits (last day)"
 					],
 					"visibleSeries":
 					[
 						"using license",
-						"pushing commits (last month)"
+						"pushing commits (last four weeks)"
 					],
 					"slice": [0, 106],
 					"default": true
@@ -64,14 +64,14 @@ permalink: /users-activity
 					"series":
 					[
 						"using license",
-						"pushing commits (last month)",
+						"pushing commits (last four weeks)",
 						"pushing commits (last week)",
 						"pushing commits (last day)"
 					],
 					"visibleSeries":
 					[
 						"using license",
-						"pushing commits (last month)"
+						"pushing commits (last four weeks)"
 					]
 				}
 			]
@@ -81,7 +81,7 @@ permalink: /users-activity
 			<i>Using license</i> shows how many GitHub Enterprise licenses were used at a given date.
 		</p>
 		<p>
-			<i>Pushing commits</i> corresponds to how many different people pushed commits to the appliance in the last month, week, or day.
+			<i>Pushing commits</i> corresponds to how many different people pushed commits to the appliance in the last four weeks, week, or day.
 		</p>
 	</div>
 	<div class="info-box">

--- a/updater/reports/ReportUsers.py
+++ b/updater/reports/ReportUsers.py
@@ -1,12 +1,12 @@
 from .ReportDaily import *
 
-# Lists how many users pushed commits vs. how many used a seat in the last day, week, and month
+# Lists how many users pushed commits vs. how many used a seat in the last day, week, and four weeks
 class ReportUsers(ReportDaily):
 	def name(self):
 		return "users"
 
 	def updateDailyData(self):
-		self.header, newData = self.parseData(self.executeQuery(self.query(self.yesterday())))
+		self.header, newData = self.parseData(self.executeQuery(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()
@@ -36,20 +36,20 @@ class ReportUsers(ReportDaily):
 				users.suspended_at IS NULL'''
 
 	# Collects the number of pushing users and users using a seat
-	def query(self, date):
-		# Also compute the stats for a 7-day and a 30-day period
-		sevenDaysEarlier = date - datetime.timedelta(6)
-		thirtyDaysEarlier = date - datetime.timedelta(29)
+	def query(self):
+		oneDayAgo = self.yesterday()
+		oneWeekAgo = self.daysAgo(7)
+		fourWeeksAgo = self.daysAgo(28)
 
 		return '''
 			SELECT
-				"''' + str(date) + '''" AS date,
+				"''' + str(oneDayAgo) + '''" AS date,
 				usersPushingYesterday.count AS "pushing commits (last day)",
 				usersPushingLastWeek.count AS "pushing commits (last week)",
-				usersPushingLastMonth.count AS "pushing commits (last month)",
+				usersPushingLastFourWeeks.count AS "pushing commits (last four weeks)",
 				usersUsingSeat.count AS "using license"
 			FROM
-				(''' + self.usersPushingSubquery([date, date]) + ''') AS usersPushingYesterday,
-				(''' + self.usersPushingSubquery([sevenDaysEarlier, date]) + ''') AS usersPushingLastWeek,
-				(''' + self.usersPushingSubquery([thirtyDaysEarlier, date]) + ''') AS usersPushingLastMonth,
+				(''' + self.usersPushingSubquery([oneDayAgo, oneDayAgo]) + ''') AS usersPushingYesterday,
+				(''' + self.usersPushingSubquery([oneWeekAgo, oneDayAgo]) + ''') AS usersPushingLastWeek,
+				(''' + self.usersPushingSubquery([fourWeeksAgo, oneDayAgo]) + ''') AS usersPushingLastFourWeeks,
 				(''' + self.usersUsingSeatSubquery() + ''') AS usersUsingSeat'''


### PR DESCRIPTION
The user activity chart stems from before most sliding windows and aggregation methods were switched from 30-day intervals to 4-week intervals. The benefit of this is that weekends are evened out, which avoids accidentally misinterpreting some fluctuations.

This changes the user activity chart accordingly for consistency.

Additionally, the time range computation in the updater report receives a minor refactoring based on the more recent reports.

Note that this change will invalidate previously recorded data based on 30-day intervals. However, no action is taken, because the difference between data aggregated over 28 and 30 days is expected to be subtle.

Resolves #129.