### PR TITLE
Minor refactorings and reformattings

### DIFF
--- a/updater/reports/ReportAPIRequests.py
+++ b/updater/reports/ReportAPIRequests.py
@@ -7,14 +7,14 @@ class ReportAPIRequests(ReportDaily):
 
 	def updateDailyData(self):
 		self.detailedHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("api-requests.sh"))
-		)
+			self.executeScript(self.scriptPath("api-requests.sh")))
 		if len(self.data) == 0:
 			self.header = ["date", "API requests"]
 		self.data.append(
-			[str(self.yesterday()),
-			sum(map(lambda x: int(x[3] if len(x) > 2 else 0), newData))]
-		)
+			[
+				str(self.yesterday()),
+				sum(map(lambda x: int(x[3] if len(x) > 2 else 0), newData)),
+			])
 		self.detailedData = newData[:25]
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportContributorsByOrg.py
+++ b/updater/reports/ReportContributorsByOrg.py
@@ -12,12 +12,11 @@ class ReportContributorsByOrg(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])
-		))
+			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])))
 
 	# Collects the number of contributors per organization
 	def query(self, timeRange):
-		query = '''
+		return '''
 			SELECT
 				users.login AS organization,
 				COUNT(DISTINCT pull_requests.user_id) AS contributors
@@ -26,14 +25,14 @@ class ReportContributorsByOrg(Report):
 				JOIN repositories ON repositories.id = pull_requests.repository_id
 				JOIN users ON users.id = repositories.owner_id
 			WHERE
-				pull_requests.created_at IS NOT NULL AND CAST(pull_requests.created_at AS date) BETWEEN "''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
-		''' + self.andExcludedUsers("users.login") + '''
+				pull_requests.created_at IS NOT NULL
+				AND CAST(pull_requests.created_at AS date) BETWEEN
+					"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+				''' + self.andExcludedUsers("users.login") + '''
 			GROUP by
 				users.id
 			ORDER by
 				contributors DESC,
 				users.id ASC
 			LIMIT
-				50
-		'''
-		return query
+				50'''

--- a/updater/reports/ReportContributorsByRepo.py
+++ b/updater/reports/ReportContributorsByRepo.py
@@ -12,12 +12,11 @@ class ReportContributorsByRepo(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])
-		))
+			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])))
 
 	# Collects the number of contributors per repository
 	def query(self, timeRange):
-		query = '''
+		return '''
 			SELECT
 				CONCAT(users.login, "/", repositories.name) AS repository,
 				COUNT(DISTINCT pull_requests.user_id) AS contributors
@@ -26,14 +25,14 @@ class ReportContributorsByRepo(Report):
 				JOIN repositories on repositories.id = pull_requests.repository_id
 				JOIN users on users.id = repositories.owner_id
 			WHERE
-				pull_requests.created_at IS NOT NULL AND CAST(pull_requests.created_at AS date) BETWEEN "''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
-		''' + self.andExcludedUsers("users.login") + '''
+				pull_requests.created_at IS NOT NULL
+				AND CAST(pull_requests.created_at AS date) BETWEEN
+					"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+				''' + self.andExcludedUsers("users.login") + '''
 			GROUP BY
 				repositories.id
 			ORDER BY
 				contributors DESC,
 				repositories.id ASC
 			LIMIT
-				50
-		'''
-		return query
+				50'''

--- a/updater/reports/ReportForksToOrgs.py
+++ b/updater/reports/ReportForksToOrgs.py
@@ -19,7 +19,7 @@ class ReportForksToOrgs(ReportDaily):
 
 	# Collects the number of forks in organizations
 	def query(self):
-		query = '''
+		return '''
 			SELECT
 				CONCAT(orgs.login, "/", repos.name) AS fork,
 				CAST(repos.created_at AS date) AS "creation date"
@@ -29,16 +29,14 @@ class ReportForksToOrgs(ReportDaily):
 				users AS parentOrgs,
 				repositories AS parentRepos
 			WHERE
-				orgs.type = "organization" AND
-				repos.owner_id = orgs.id AND
-				parentOrgs.type = "organization" AND
-				parentRepos.owner_id = parentOrgs.id AND
-				parentRepos.id = repos.parent_id
-				''' + self.andExcludedEntities("orgs.login") \
-					+ self.andExcludedEntities("repos.name") \
-					+ self.andExcludedEntities("parentOrgs.login") \
-					+ self.andExcludedEntities("parentRepos.name") + '''
+				orgs.type = "organization"
+				AND repos.owner_id = orgs.id
+				AND parentOrgs.type = "organization"
+				AND parentRepos.owner_id = parentOrgs.id
+				AND parentRepos.id = repos.parent_id
+				''' + self.andExcludedEntities("orgs.login") + '''
+				''' + self.andExcludedEntities("repos.name") + '''
+				''' + self.andExcludedEntities("parentOrgs.login") + '''
+				''' + self.andExcludedEntities("parentRepos.name") + '''
 			ORDER BY
-				repos.created_at DESC
-		'''
-		return query
+				repos.created_at DESC'''

--- a/updater/reports/ReportGitDownload.py
+++ b/updater/reports/ReportGitDownload.py
@@ -7,24 +7,25 @@ class ReportGitDownload(ReportDaily):
 
 	def updateDailyData(self):
 		self.detailedHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("git-download.sh"))
-		)
+			self.executeScript(self.scriptPath("git-download.sh")))
 		if len(self.data) == 0:
-			self.header = [
-				"date",
-				"clones",
-				"fetches",
-				"clone traffic [GB]",
-				"fetch traffic [GB]",
-			]
-		self.data.append([
-			str(self.yesterday()),
-			sum(map(lambda x: int(x[3] if len(x) > 2 and x[2] == "true" else 0), newData)),
-			sum(map(lambda x: int(x[3] if len(x) > 2 and x[2] != "true" else 0), newData)),
-			sum(map(lambda x: int(x[4] if len(x) > 3 and x[2] == "true" else 0), newData))//(1024**3),
-			sum(map(lambda x: int(x[4] if len(x) > 3 and x[2] != "true" else 0), newData))//(1024**3),
-		])
+			self.header = \
+				[
+					"date",
+					"clones",
+					"fetches",
+					"clone traffic [GB]",
+					"fetch traffic [GB]",
+				]
+		self.data.append(
+			[
+				str(self.yesterday()),
+				sum(map(lambda x: int(x[3] if len(x) > 2 and x[2] == "true" else 0), newData)),
+				sum(map(lambda x: int(x[3] if len(x) > 2 and x[2] != "true" else 0), newData)),
+				sum(map(lambda x: int(x[4] if len(x) > 3 and x[2] == "true" else 0), newData)) // (1024 ** 3),
+				sum(map(lambda x: int(x[4] if len(x) > 3 and x[2] != "true" else 0), newData)) // (1024 ** 3),
+			])
 		self.detailedHeader[4] = "download [GB]"
-		self.detailedData = map(lambda x: [x[0], x[1], x[2], x[3], round(int(x[4])/(1024**3))], newData[:25])
+		self.detailedData = map(lambda x: [x[0], x[1], x[2], x[3], round(int(x[4]) / (1024 ** 3))], newData[:25])
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportGitRequests.py
+++ b/updater/reports/ReportGitRequests.py
@@ -7,14 +7,14 @@ class ReportGitRequests(ReportDaily):
 
 	def updateDailyData(self):
 		self.detailedHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("git-requests.sh"))
-		)
+			self.executeScript(self.scriptPath("git-requests.sh")))
 		if len(self.data) == 0:
 			self.header = ["date", "Git requests"]
 		self.data.append(
-			[str(self.yesterday()),
-			sum(map(lambda x: int(x[2] if len(x) > 1 else 0), newData))]
-		)
+			[
+				str(self.yesterday()),
+				sum(map(lambda x: int(x[2] if len(x) > 1 else 0), newData)),
+			])
 		self.detailedData = newData[:25]
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportGitVersions.py
+++ b/updater/reports/ReportGitVersions.py
@@ -11,5 +11,4 @@ class ReportGitVersions(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeScript(self.scriptPath("git-versions.sh"))
-		)
+			self.executeScript(self.scriptPath("git-versions.sh")))

--- a/updater/reports/ReportOrgCollaboration.py
+++ b/updater/reports/ReportOrgCollaboration.py
@@ -20,89 +20,121 @@ class ReportOrgCollaboration(Report):
 		          + self.orgCollaborationMatrix([twoYearsAgo, oneDayAgo])
 
 	def pushCountQuery(self, timeRange):
-		query = '''
-			SELECT orgs.login AS org_name, orgs.id AS org_id, pusher_id, COUNT(*) AS push_count
-			FROM users AS orgs, repositories, pushes
-			WHERE orgs.type = "organization"
-			  AND orgs.id = repositories.owner_id
-			  AND repositories.id = pushes.repository_id
-			  AND cast(pushes.created_at AS DATE) BETWEEN "''' + str(timeRange[0]) + '''" and "''' + str(timeRange[1]) + '''"
-			  ''' + self.andExcludedEntities("orgs.login") \
-			      + self.andExcludedEntities("repositories.name") \
-			      + self.andExcludeMemberlessOrganizations("orgs") + '''
-			GROUP BY org_id, pusher_id
-		'''
-		return query
+		return '''
+			SELECT
+				orgs.login AS org_name,
+				orgs.id AS org_id,
+				pusher_id,
+				COUNT(*) AS push_count
+			FROM
+				users AS orgs,
+				repositories,
+				pushes
+			WHERE
+				orgs.type = "organization"
+				AND orgs.id = repositories.owner_id
+				AND repositories.id = pushes.repository_id
+				AND CAST(pushes.created_at AS DATE) BETWEEN
+					"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+				''' + self.andExcludedEntities("orgs.login") + '''
+				''' + self.andExcludedEntities("repositories.name") + '''
+				''' + self.andExcludeMemberlessOrganizations("orgs") + '''
+			GROUP BY
+				org_id,
+				pusher_id'''
 
 	# Calculate the "home" org of a user based on the number of pushes in given time range
 	# Explained here: https://stackoverflow.com/a/28090544
 	def homeOrgQuery(self, timeRange):
-		query = '''
-			SELECT a.org_name, a.org_id, a.pusher_id, a.push_count
-			FROM users, (''' + self.pushCountQuery(timeRange) +''' ) AS a
-				LEFT JOIN  (''' + self.pushCountQuery(timeRange) +''' ) AS b
-				ON     a.pusher_id = b.pusher_id
-				   AND (   a.push_count < b.push_count
-				        OR (a.push_count = b.push_count AND a.pusher_id != b.pusher_id)
-				       )
-			WHERE b.push_count is NULL AND a.pusher_id = users.id ''' \
-				+ self.andExcludedUsers("users.login")
-		return query
+		return '''
+			SELECT
+				a.org_name,
+				a.org_id,
+				a.pusher_id,
+				a.push_count
+			FROM
+				users,
+				(''' + self.pushCountQuery(timeRange) + ''') AS a
+				LEFT JOIN
+				(''' + self.pushCountQuery(timeRange) +''' ) AS b
+					ON
+						a.pusher_id = b.pusher_id
+						AND
+						(
+							a.push_count < b.push_count
+							OR (a.push_count = b.push_count AND a.pusher_id != b.pusher_id)
+						)
+			WHERE
+				b.push_count is NULL
+				AND a.pusher_id = users.id
+				''' + self.andExcludedUsers("users.login")
 
 	# Calculates a table that contains all users that have contributed to a
 	# given organization. The contributions could have been made via direct
 	# pushes or via merged pull requests.
 	def contributorsToOrgQuery(self, timeRange):
-		query = '''
-			SELECT org_name, org_id, contributor_id
-			FROM (
-				SELECT orgs.login AS org_name,
-				       orgs.id AS org_id,
-				       pushes.pusher_id AS contributor_id
-				FROM users AS orgs,
-				     repositories,
-				     pushes
-				WHERE orgs.type = "organization"
-				  AND orgs.id = repositories.owner_id
-				  AND repositories.id = pushes.repository_id
-				  AND cast(pushes.created_at AS DATE) BETWEEN "''' + str(timeRange[0]) + '''" and "''' + str(timeRange[1]) + '''"
-				  ''' + self.andExcludedEntities("orgs.login") \
-				      + self.andExcludedEntities("repositories.name") + '''
+		return '''
+			SELECT
+				org_name,
+				org_id,
+				contributor_id
+			FROM
+				(
+					SELECT
+						orgs.login AS org_name,
+						orgs.id AS org_id,
+						pushes.pusher_id AS contributor_id
+					FROM
+						users AS orgs,
+						repositories,
+						pushes
+					WHERE
+						orgs.type = "organization"
+						AND orgs.id = repositories.owner_id
+						AND repositories.id = pushes.repository_id
+						AND cast(pushes.created_at AS DATE) BETWEEN
+							"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+						''' + self.andExcludedEntities("orgs.login") + '''
+						''' + self.andExcludedEntities("repositories.name") + '''
 
-				UNION
+					UNION
 
-				SELECT orgs.login AS org_name,
-				       orgs.id AS org_id,
-				       pull_requests.user_id AS contributor_id
-				FROM users AS orgs,
-				     repositories,
-				     pull_requests
-				WHERE orgs.type = "organization"
-				  AND orgs.id = repositories.owner_id
-				  AND repositories.id = pull_requests.repository_id
-				  AND pull_requests.merged_at IS NOT NULL
-				  AND cast(pull_requests.created_at AS DATE) BETWEEN "''' + str(timeRange[0]) + '''" and "''' + str(timeRange[1]) + '''"
-				  ''' + self.andExcludedEntities("orgs.login") \
-				      + self.andExcludedEntities("repositories.name") + '''
-			) contributors
-			GROUP BY org_id, contributor_id
-		'''
-		return query
+					SELECT
+						orgs.login AS org_name,
+						orgs.id AS org_id,
+						pull_requests.user_id AS contributor_id
+					FROM
+						users AS orgs,
+						repositories,
+						pull_requests
+					WHERE
+						orgs.type = "organization"
+						AND orgs.id = repositories.owner_id
+						AND repositories.id = pull_requests.repository_id
+						AND pull_requests.merged_at IS NOT NULL
+						AND CAST(pull_requests.created_at AS DATE) BETWEEN
+							"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+						''' + self.andExcludedEntities("orgs.login") + '''
+						''' + self.andExcludedEntities("repositories.name") + '''
+				) AS contributors
+			GROUP BY
+				org_id,
+				contributor_id'''
 
 	def collaboration(self, timeRange):
-		query = '''
-			SELECT source.org_name AS source,
-			       target.org_name AS target,
-			       COUNT(*) AS org_count
+		return '''
+			SELECT
+				source.org_name AS source,
+				target.org_name AS target,
+				COUNT(*) AS org_count
 			FROM
 				(''' + self.homeOrgQuery(timeRange) + ''') AS source
 				LEFT JOIN (''' + self.contributorsToOrgQuery(timeRange) + ''') AS target
 					ON source.pusher_id = target.contributor_id
 			WHERE source.org_id != target.org_id
-			GROUP BY source.org_id,
-			         target.org_id
-		'''
-		return query
+			GROUP BY
+				source.org_id,
+				target.org_id'''
 
 	def orgCollaborationMatrix(self, timeRange):
 		_, newData = self.parseData(self.executeQuery(self.collaboration(timeRange)))

--- a/updater/reports/ReportOrgOwners.py
+++ b/updater/reports/ReportOrgOwners.py
@@ -22,6 +22,4 @@ class ReportOrgOwners(Report):
 					                   .order("login")
 					                   .join(",")
 					puts "#{org.login}\t#{owners}\n"
-				end
-			''')
-		)
+				end'''))

--- a/updater/reports/ReportOrgsAbandoned.py
+++ b/updater/reports/ReportOrgsAbandoned.py
@@ -16,7 +16,7 @@ class ReportOrgsAbandoned(ReportDaily):
 		self.sortDataByDate()
 
 	def query(self):
-		query = '''
+		return '''
 			SELECT
 				users.login AS "organization",
 				DATE(MAX(pushes.created_at)) AS "last push"
@@ -26,13 +26,11 @@ class ReportOrgsAbandoned(ReportDaily):
 				JOIN pushes ON pushes.repository_id = repositories.id
 			WHERE
 				users.type = "organization"
-				AND repositories.maintained = 1 ''' + \
-				self.andExcludedEntities("users.login") + '''
+				AND repositories.maintained = 1
+				''' + self.andExcludedEntities("users.login") + '''
 			GROUP BY
 				users.id
 			HAVING
 				CAST(MAX(pushes.created_at) AS DATE) < "''' + str(self.daysAgo(365)) + '''"
 			ORDER BY
-				MAX(pushes.created_at)
-		'''
-		return query
+				MAX(pushes.created_at)'''

--- a/updater/reports/ReportOrgsTotal.py
+++ b/updater/reports/ReportOrgsTotal.py
@@ -6,22 +6,19 @@ class ReportOrgsTotal(ReportDaily):
 		return "orgs-total"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(
-			self.executeQuery(self.query())
-		)
+		newHeader, newData = self.parseData(self.executeQuery(self.query()))
 		self.header = newHeader if newHeader else self.header
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()
 
 	def query(self):
-		query = '''
+		return '''
 			SELECT
 				"''' + str(self.yesterday()) + '''" AS date,
 				COUNT(*) AS total
 			FROM
 				users AS orgs
 			WHERE
-				orgs.type = "Organization" ''' + \
-				self.andExcludedEntities("orgs.login")
-		return query
+				orgs.type = "Organization"
+				''' + self.andExcludedEntities("orgs.login")

--- a/updater/reports/ReportPRByOrg.py
+++ b/updater/reports/ReportPRByOrg.py
@@ -12,33 +12,40 @@ class ReportPRByOrg(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])
-		))
+			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])))
 
 	# Collects the number of merged and new pull requests per organization
 	def query(self, timeRange):
-		query = '''
+		return '''
 			SELECT
 				users.login AS organization,
 				COUNT(
-					CASE WHEN pull_requests.merged_at IS NOT NULL AND CAST(pull_requests.merged_at AS date) BETWEEN "''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
-					THEN 1 ELSE NULL END
-				) AS merged,
+					CASE
+						WHEN
+							pull_requests.merged_at IS NOT NULL
+							AND CAST(pull_requests.merged_at AS date) BETWEEN
+								"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+						THEN 1
+						ELSE NULL
+					END) AS merged,
 				COUNT(
-					CASE WHEN pull_requests.created_at IS NOT NULL AND CAST(pull_requests.created_at AS date) BETWEEN "''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
-					THEN 1 ELSE NULL END
-				) AS new
+					CASE
+						WHEN
+							pull_requests.created_at IS NOT NULL
+							AND CAST(pull_requests.created_at AS date) BETWEEN
+								"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+						THEN 1
+						ELSE NULL
+					END) AS new
 			FROM
 				pull_requests
 				JOIN repositories ON repositories.id = pull_requests.repository_id
 				JOIN users ON users.id = repositories.owner_id
-		''' + self.whereExcludedUsers("users.login") + '''
+			''' + self.whereExcludedUsers("users.login") + '''
 			GROUP BY
 				users.id
 			ORDER BY
 				merged DESC,
 				users.id ASC
 			LIMIT
-				50
-		'''
-		return query
+				50'''

--- a/updater/reports/ReportPRByRepo.py
+++ b/updater/reports/ReportPRByRepo.py
@@ -12,33 +12,42 @@ class ReportPRByRepo(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])
-		))
+			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])))
 
 	# Collects the number of merged and new pull requests per repository
 	def query(self, timeRange):
-		query = '''
+		return '''
 			SELECT
 				CONCAT(users.login, "/", repositories.name) as repository,
 				COUNT(
-					CASE WHEN pull_requests.merged_at IS NOT NULL AND CAST(pull_requests.merged_at as date) between "''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
-					THEN 1 ELSE NULL END
-				) AS merged,
+					CASE
+						WHEN
+							pull_requests.merged_at IS NOT NULL
+							AND CAST(pull_requests.merged_at as date) BETWEEN
+								"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+						THEN 1
+						ELSE NULL
+					END) AS merged,
 				COUNT(
-					CASE WHEN pull_requests.created_at IS NOT NULL AND CAST(pull_requests.created_at as date) between "''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
-					THEN 1 ELSE NULL END
-				) AS new
+					CASE
+						WHEN
+							pull_requests.created_at IS NOT NULL
+							AND CAST(pull_requests.created_at as date) BETWEEN
+								"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+						THEN 1
+						ELSE NULL
+					END) AS new
 			FROM
 				pull_requests
-				join repositories ON repositories.id = pull_requests.repository_id
-				join users on users.id = repositories.owner_id
-		''' + self.whereExcludedUsers("users.login") + '''
+				JOIN repositories
+					ON repositories.id = pull_requests.repository_id
+				JOIN users
+					ON users.id = repositories.owner_id
+			''' + self.whereExcludedUsers("users.login") + '''
 			GROUP BY
 				repositories.id
 			ORDER BY
 				merged DESC,
 				repositories.id ASC
 			LIMIT
-				50
-		'''
-		return query
+				50'''

--- a/updater/reports/ReportPRHistory.py
+++ b/updater/reports/ReportPRHistory.py
@@ -8,8 +8,7 @@ class ReportPRHistory(ReportDaily):
 	def updateDailyData(self):
 		# Collect the missing data that should be added with this update
 		newHeader, newData = self.parseData(
-			self.executeQuery(self.query(self.timeRangeToUpdate()))
-		)
+			self.executeQuery(self.query(self.timeRangeToUpdate())))
 		self.header = newHeader if newHeader else self.header
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
@@ -17,7 +16,7 @@ class ReportPRHistory(ReportDaily):
 
 	# Collects the number of either merged or new pull requests
 	def subquery(self, type, timeRange):
-		query = '''
+		return '''
 			SELECT
 				DATE_FORMAT(pull_requests.''' + type + ''', "%Y-%m-%d") AS date,
 				COUNT(*) AS count
@@ -25,19 +24,18 @@ class ReportPRHistory(ReportDaily):
 				pull_requests,
 				users
 			WHERE
-				CAST(pull_requests.''' + type + ''' AS date) BETWEEN "''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''" AND
-				pull_requests.user_id = users.id
-		''' + self.andExcludedUsers("users.login") + '''
+				CAST(pull_requests.''' + type + ''' AS date) BETWEEN
+					"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+				AND pull_requests.user_id = users.id
+				''' + self.andExcludedUsers("users.login") + '''
 			GROUP BY
 				date_format(pull_requests.''' + type + ''', "%Y-%m-%d")
 			ORDER BY
-				date DESC
-		'''
-		return query
+				date DESC'''
 
 	# Collects all the results for merged and new pull requests
 	def query(self, timeRange):
-		query = '''
+		return '''
 			SELECT
 				created.date AS date,
 				merged.count AS merged,
@@ -50,6 +48,4 @@ class ReportPRHistory(ReportDaily):
 			GROUP BY
 				created.date
 			ORDER BY
-				date DESC
-		'''
-		return query
+				date DESC'''

--- a/updater/reports/ReportReposPersonalNonOwnerPushes.py
+++ b/updater/reports/ReportReposPersonalNonOwnerPushes.py
@@ -18,7 +18,8 @@ class ReportReposPersonalNonOwnerPushes(ReportDaily):
 
 	def query(self):
 		fourWeeksAgo = self.daysAgo(28)
-		query = '''
+
+		return '''
 			SELECT
 				CONCAT(users.login, "/", repositories.name) as "repository",
 				COUNT(DISTINCT(pushes.pusher_id)) as "nonowner pushers"
@@ -29,11 +30,10 @@ class ReportReposPersonalNonOwnerPushes(ReportDaily):
 			WHERE
 				users.type = "user"
 				AND users.suspended_at IS NULL
-				AND CAST(pushes.created_at AS DATE) BETWEEN "''' + str(fourWeeksAgo) + '''" AND "''' + str(self.yesterday()) + '''"
+				AND CAST(pushes.created_at AS DATE) BETWEEN
+					"''' + str(fourWeeksAgo) + '''" AND "''' + str(self.yesterday()) + '''"
 				AND pushes.pusher_id != users.id
 			GROUP BY
 				repositories.id
 			ORDER BY
-				2 DESC, 1
-		'''
-		return query
+				2 DESC, 1'''

--- a/updater/reports/ReportRepositoryHistory.py
+++ b/updater/reports/ReportRepositoryHistory.py
@@ -6,9 +6,7 @@ class ReportRepositoryHistory(ReportDaily):
 		return "repository-history"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(
-			self.executeQuery(self.query())
-		)
+		newHeader, newData = self.parseData(self.executeQuery(self.query()))
 		self.header = newHeader if newHeader else self.header
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
@@ -23,18 +21,19 @@ class ReportRepositoryHistory(ReportDaily):
 				repositories
 				JOIN users ON repositories.owner_id = users.id
 			WHERE
-				TRUE ''' + self.andExcludedEntities("users.login") \
-				         + self.andExcludedEntities("repositories.name")
+				TRUE
+				''' + self.andExcludedEntities("users.login") + '''
+				''' + self.andExcludedEntities("repositories.name")
 
 		if userType != None:
-			query += ''' AND
-				users.type = "''' + userType + '''"'''
+			query += '''
+				AND users.type = "''' + userType + '''"'''
 
 		return query
 
 	# Collects the number of repositories in total, in organizations, and in user accounts
 	def query(self):
-		query = '''
+		return '''
 			SELECT
 				"''' + str(self.yesterday()) + '''" AS date,
 				total.count AS total,
@@ -43,7 +42,4 @@ class ReportRepositoryHistory(ReportDaily):
 			FROM
 				(''' + self.subquery(None) + ''') AS total,
 				(''' + self.subquery("Organization") + ''') AS organizationSpace,
-				(''' + self.subquery("User") + ''') AS userSpace
-			'''
-
-		return query
+				(''' + self.subquery("User") + ''') AS userSpace'''

--- a/updater/reports/ReportTeamsLegacy.py
+++ b/updater/reports/ReportTeamsLegacy.py
@@ -20,9 +20,7 @@ class ReportTeamsLegacy(ReportDaily):
 							puts "#{o.login}\t#{t.name}\t#{t.members.size}"
 						}
 					end
-				end
-			''')
-		)
+				end'''))
 		if len(self.data) == 0:
 			self.header = ["date", "legacy admin teams"]
 		self.data.append([str(self.yesterday()), len(self.detailedData)])

--- a/updater/reports/ReportTeamsTotal.py
+++ b/updater/reports/ReportTeamsTotal.py
@@ -6,22 +6,19 @@ class ReportTeamsTotal(ReportDaily):
 		return "teams-total"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(
-			self.executeQuery(self.query())
-		)
+		newHeader, newData = self.parseData(self.executeQuery(self.query()))
 		self.header = newHeader if newHeader else self.header
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()
 
 	def query(self):
-		query = '''
+		return '''
 			SELECT
 				"''' + str(self.yesterday()) + '''" AS date,
 				COUNT(*) AS total
 			FROM
 				teams, users AS orgs
 			WHERE
-				teams.organization_id = orgs.id ''' + \
-				self.andExcludedEntities("orgs.login")
-		return query
+				teams.organization_id = orgs.id
+				''' + self.andExcludedEntities("orgs.login")

--- a/updater/reports/ReportTokenlessAuth.py
+++ b/updater/reports/ReportTokenlessAuth.py
@@ -7,14 +7,14 @@ class ReportTokenlessAuth(ReportDaily):
 
 	def updateDailyData(self):
 		self.detailedHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("tokenless-auth.sh"))
-		)
+			self.executeScript(self.scriptPath("tokenless-auth.sh")))
 		if len(self.data) == 0:
 			self.header = ["date", "tokenless authentications"]
 		self.data.append(
-			[str(self.yesterday()),
-			sum(map(lambda x: int(x[2] if len(x) > 1 else 0), newData))]
-		)
+			[
+				str(self.yesterday()),
+				sum(map(lambda x: int(x[2] if len(x) > 1 else 0), newData)),
+			])
 		self.detailedData = newData[:25]
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportUsers.py
+++ b/updater/reports/ReportUsers.py
@@ -6,9 +6,7 @@ class ReportUsers(ReportDaily):
 		return "users"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(
-			self.executeQuery(self.query(self.yesterday()))
-		)
+		newHeader, newData = self.parseData(self.executeQuery(self.query(self.yesterday())))
 		self.header = newHeader if newHeader else self.header
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
@@ -16,36 +14,35 @@ class ReportUsers(ReportDaily):
 
 	# Collects the number of users who pushed commits yesterday
 	def usersPushingSubquery(self, timeRange):
-		query = '''
+		return '''
 			SELECT
 				COUNT(DISTINCT users.id) AS count
 			FROM
 				pushes
 				JOIN users ON users.id = pushes.pusher_id
 			WHERE
-				CAST(pushes.created_at AS DATE) BETWEEN "''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
-		''' + self.andExcludedUsers("users.login")
-		return query
+				CAST(pushes.created_at AS DATE) BETWEEN
+					"''' + str(timeRange[0]) + '''" AND "''' + str(timeRange[1]) + '''"
+				''' + self.andExcludedUsers("users.login")
 
 	# Collects the number of users who currently use up a seat
 	def usersUsingSeatSubquery(self):
-		query = '''
+		return '''
 			SELECT
 				COUNT(*) AS count
 			FROM
 				users
 			WHERE
 				users.type = "User" AND
-				users.suspended_at IS NULL
-		'''
-		return query
+				users.suspended_at IS NULL'''
 
 	# Collects the number of pushing users and users using a seat
 	def query(self, date):
 		# Also compute the stats for a 7-day and a 30-day period
 		sevenDaysEarlier = date - datetime.timedelta(6)
 		thirtyDaysEarlier = date - datetime.timedelta(29)
-		query = '''
+
+		return '''
 			SELECT
 				"''' + str(date) + '''" AS date,
 				usersPushingYesterday.count AS "pushing commits (last day)",
@@ -56,6 +53,4 @@ class ReportUsers(ReportDaily):
 				(''' + self.usersPushingSubquery([date, date]) + ''') AS usersPushingYesterday,
 				(''' + self.usersPushingSubquery([sevenDaysEarlier, date]) + ''') AS usersPushingLastWeek,
 				(''' + self.usersPushingSubquery([thirtyDaysEarlier, date]) + ''') AS usersPushingLastMonth,
-				(''' + self.usersUsingSeatSubquery() + ''') AS usersUsingSeat
-		'''
-		return query
+				(''' + self.usersUsingSeatSubquery() + ''') AS usersUsingSeat'''


### PR DESCRIPTION
I got a little bit frustrated at the fact that our reports are not very consistent structure-wise. As I don’t want to encourage contributors (and myself) to continue this trend, I thought it best to clean this all up :smiley:.

For this reason, this pull request applies multiple minor refactorings and reformattings.

I verified that there are no semantic changes whatsoever, and tested that the results obtained with this patch are the same as without it.

1. Make unused return variables anonymous.

2. Some weird-looking 1TBS indentations are reformatted.

3. Separate operators from the operands with spaces.

4. Remove unused return variables and return directly instead.

5. Put connective operators at the beginning of new lines.

6. Break long lines appropriately.

7. Capitalize SQL keywords.

8. Add trailing commas to multiline array initializers.