### PR TITLE
Rewrite headers on every update

### DIFF
--- a/updater/reports/ReportAPIRequests.py
+++ b/updater/reports/ReportAPIRequests.py
@@ -8,8 +8,7 @@ class ReportAPIRequests(ReportDaily):
 	def updateDailyData(self):
 		self.detailedHeader, newData = self.parseData(
 			self.executeScript(self.scriptPath("api-requests.sh")))
-		if len(self.data) == 0:
-			self.header = ["date", "API requests"]
+		self.header = ["date", "API requests"]
 		self.data.append(
 			[
 				str(self.yesterday()),

--- a/updater/reports/ReportForksToOrgs.py
+++ b/updater/reports/ReportForksToOrgs.py
@@ -11,8 +11,7 @@ class ReportForksToOrgs(ReportDaily):
 
 	def updateDailyData(self):
 		self.detailedHeader, self.detailedData = self.parseData(self.executeQuery(self.query()))
-		if len(self.data) == 0:
-			self.header = ["date", "forks to organizations"]
+		self.header = ["date", "forks to organizations"]
 		self.data.append([str(self.yesterday()), len(self.detailedData)])
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportGitDownload.py
+++ b/updater/reports/ReportGitDownload.py
@@ -8,15 +8,14 @@ class ReportGitDownload(ReportDaily):
 	def updateDailyData(self):
 		self.detailedHeader, newData = self.parseData(
 			self.executeScript(self.scriptPath("git-download.sh")))
-		if len(self.data) == 0:
-			self.header = \
-				[
-					"date",
-					"clones",
-					"fetches",
-					"clone traffic [GB]",
-					"fetch traffic [GB]",
-				]
+		self.header = \
+			[
+				"date",
+				"clones",
+				"fetches",
+				"clone traffic [GB]",
+				"fetch traffic [GB]",
+			]
 		self.data.append(
 			[
 				str(self.yesterday()),

--- a/updater/reports/ReportGitRequests.py
+++ b/updater/reports/ReportGitRequests.py
@@ -8,8 +8,7 @@ class ReportGitRequests(ReportDaily):
 	def updateDailyData(self):
 		self.detailedHeader, newData = self.parseData(
 			self.executeScript(self.scriptPath("git-requests.sh")))
-		if len(self.data) == 0:
-			self.header = ["date", "Git requests"]
+		self.header = ["date", "Git requests"]
 		self.data.append(
 			[
 				str(self.yesterday()),

--- a/updater/reports/ReportOrgsAbandoned.py
+++ b/updater/reports/ReportOrgsAbandoned.py
@@ -9,8 +9,7 @@ class ReportOrgsAbandoned(ReportDaily):
 
 	def updateDailyData(self):
 		self.detailedHeader, self.detailedData = self.parseData(self.executeQuery(self.query()))
-		if len(self.data) == 0:
-			self.header = ["date", "abandoned organizations"]
+		self.header = ["date", "abandoned organizations"]
 		self.data.append([str(self.yesterday()), len(self.detailedData)])
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportOrgsTotal.py
+++ b/updater/reports/ReportOrgsTotal.py
@@ -6,8 +6,7 @@ class ReportOrgsTotal(ReportDaily):
 		return "orgs-total"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(self.executeQuery(self.query()))
-		self.header = newHeader if newHeader else self.header
+		self.header, newData = self.parseData(self.executeQuery(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportPRHistory.py
+++ b/updater/reports/ReportPRHistory.py
@@ -7,9 +7,8 @@ class ReportPRHistory(ReportDaily):
 
 	def updateDailyData(self):
 		# Collect the missing data that should be added with this update
-		newHeader, newData = self.parseData(
+		self.header, newData = self.parseData(
 			self.executeQuery(self.query(self.timeRangeToUpdate())))
-		self.header = newHeader if newHeader else self.header
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportPRUsage.py
+++ b/updater/reports/ReportPRUsage.py
@@ -18,8 +18,7 @@ class ReportPRUsage(ReportDaily):
 				date += datetime.timedelta(days_in_month)
 				_, newData = self.parseData(self.executeQuery(self.query(date)))
 				self.data.extend(newData)
-		newHeader, newData = self.parseData(self.executeQuery(self.query(self.yesterday())))
-		self.header = newHeader if newHeader else self.header
+		self.header, newData = self.parseData(self.executeQuery(self.query(self.yesterday())))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportRepoActivity.py
+++ b/updater/reports/ReportRepoActivity.py
@@ -10,8 +10,7 @@ class ReportRepoActivity(ReportDaily):
 		return "repository-activity"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(self.executeQuery(self.query()))
-		self.header = newHeader if newHeader else self.header
+		self.header, newData = self.parseData(self.executeQuery(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportRepoUsage.py
+++ b/updater/reports/ReportRepoUsage.py
@@ -8,8 +8,7 @@ class ReportRepoUsage(ReportDaily):
 		return "repository-usage"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(self.executeQuery(self.query()))
-		self.header = newHeader if newHeader else self.header
+		self.header, newData = self.parseData(self.executeQuery(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportReposPersonalNonOwnerPushes.py
+++ b/updater/reports/ReportReposPersonalNonOwnerPushes.py
@@ -10,8 +10,7 @@ class ReportReposPersonalNonOwnerPushes(ReportDaily):
 
 	def updateDailyData(self):
 		self.detailedHeader, self.detailedData = self.parseData(self.executeQuery(self.query()))
-		if len(self.data) == 0:
-			self.header = ["date", "personal repositories with nonowner pushes"]
+		self.header = ["date", "personal repositories with nonowner pushes"]
 		self.data.append([str(self.yesterday()), len(self.detailedData)])
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportRepositoryHistory.py
+++ b/updater/reports/ReportRepositoryHistory.py
@@ -6,8 +6,7 @@ class ReportRepositoryHistory(ReportDaily):
 		return "repository-history"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(self.executeQuery(self.query()))
-		self.header = newHeader if newHeader else self.header
+		self.header, newData = self.parseData(self.executeQuery(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportTeamsLegacy.py
+++ b/updater/reports/ReportTeamsLegacy.py
@@ -21,8 +21,7 @@ class ReportTeamsLegacy(ReportDaily):
 						}
 					end
 				end'''))
-		if len(self.data) == 0:
-			self.header = ["date", "legacy admin teams"]
+		self.header = ["date", "legacy admin teams"]
 		self.data.append([str(self.yesterday()), len(self.detailedData)])
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportTeamsTotal.py
+++ b/updater/reports/ReportTeamsTotal.py
@@ -6,8 +6,7 @@ class ReportTeamsTotal(ReportDaily):
 		return "teams-total"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(self.executeQuery(self.query()))
-		self.header = newHeader if newHeader else self.header
+		self.header, newData = self.parseData(self.executeQuery(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportTokenlessAuth.py
+++ b/updater/reports/ReportTokenlessAuth.py
@@ -8,8 +8,7 @@ class ReportTokenlessAuth(ReportDaily):
 	def updateDailyData(self):
 		self.detailedHeader, newData = self.parseData(
 			self.executeScript(self.scriptPath("tokenless-auth.sh")))
-		if len(self.data) == 0:
-			self.header = ["date", "tokenless authentications"]
+		self.header = ["date", "tokenless authentications"]
 		self.data.append(
 			[
 				str(self.yesterday()),

--- a/updater/reports/ReportUsers.py
+++ b/updater/reports/ReportUsers.py
@@ -6,8 +6,7 @@ class ReportUsers(ReportDaily):
 		return "users"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(self.executeQuery(self.query(self.yesterday())))
-		self.header = newHeader if newHeader else self.header
+		self.header, newData = self.parseData(self.executeQuery(self.query(self.yesterday())))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()


### PR DESCRIPTION
With this commit, every single update will cause the data file headers to be rewritten to their defaults.

In this way, we can easily change column labels in the data files in the future without having to worry about empty charts due to the inconsistent naming scheme (which causes the dashboard not to match the data series with the columns appropriately).

I don’t consider this a change that could accidentally break data by, for instance, switching the meaning of columns in the future. The reason is that we have the data schema mechanism in place to deal with cases where we would like to make deeper changes to the data format that would require a data migration.