### PR TITLE
Add detailed Git versions report

### DIFF
--- a/updater/reports/ReportGitVersionsNew.py
+++ b/updater/reports/ReportGitVersionsNew.py
@@ -1,0 +1,18 @@
+from .ReportDaily import *
+
+# Lists which git version was used by how many users yesterday
+class ReportGitVersionsNew(ReportDaily):
+	def name(self):
+		return "git-versions-new"
+
+	def updateDailyData(self):
+		newHeader, newData = self.parseData(
+			self.executeScript(self.scriptPath("git-versions.sh")))
+
+		self.header = ["date"] + newHeader
+
+		newData = [[str(self.yesterday())] + row for row in newData]
+
+		self.data.extend(newData)
+		self.truncateData(self.timeRangeTotal())
+		self.sortDataByDate()

--- a/updater/update-stats.py
+++ b/updater/update-stats.py
@@ -15,6 +15,7 @@ from reports.ReportForksToOrgs import *
 from reports.ReportGitDownload import *
 from reports.ReportGitRequests import *
 from reports.ReportGitVersions import *
+from reports.ReportGitVersionsNew import *
 from reports.ReportOrgActivity import *
 from reports.ReportOrgCollaboration import *
 from reports.ReportOrgOwners import *
@@ -79,6 +80,7 @@ def main():
 	ReportGitDownload(configuration, dataDirectory, metaStats).update()
 	ReportGitRequests(configuration, dataDirectory, metaStats).update()
 	ReportGitVersions(configuration, dataDirectory, metaStats).update()
+	ReportGitVersionsNew(configuration, dataDirectory, metaStats).update()
 	ReportOrgActivity(configuration, dataDirectory, metaStats).update()
 	ReportOrgCollaboration(configuration, dataDirectory, metaStats).update()
 	ReportOrgOwners(configuration, dataDirectory, metaStats).update()


### PR DESCRIPTION
This adds an extended edition of the Git versions report. In addition to tracking the used Git versions of the last day, this tracks all used Git versions every day, making an upgrade trend chart possible.

Note that this only includes the report (which gathers the data) but not the chart. Also, for compatibility, the former Git versions chart is retained for now. The migration will be done in a future pull request.

The data format is as follows:

| date | Git version | users |
|---|---|---|
| 2018-03-27 | 2.16.1 | 2 |
| 2018-03-27 | 2.14.1 | 1 |
| 2018-03-27 | 2.12.2 | 1 |
| 2018-03-27 | 2.11.0 | 1 |
| 2018-03-27 | 2.10.2 | 1 |
| 2018-03-27 | 2.7.2 | 1 |