### PR TITLE
added meta.tsv, updated documentation, fixed calendar import

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Hubble Enterprise consists of two components.
 The [*updater component*](updater/) is a Python script that queries relevant data from a GitHub Enterprise appliance and stores the results in a Git repository once a day.
 The [*docs component*](docs/) is a web application that visualizes the collected data and is hosted with [GitHub Pages](https://pages.github.com/).
 
-1. Create a new, initialized, public repository for Hubble’s data on your GitHub Enterprise appliance (for instance, `https://git.company.com/scm/hubble-data`).
+1. Create a new, initialized, public repository for Hubble’s data on your GitHub Enterprise appliance (for instance, `https://git.company.com/scm/hubble-data`) and add the [meta.tsv](meta.tsv) file to the repository.
 1. Publish Hubble’s [data repository on GitHub Pages](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages).
    Go to the repository settings, *options* tab, *GitHub Pages* section, then choose *master branch* as *source*, and click *save*.
    GitHub Enterprise will now tell you the URL of the published data pages (for instance, `https://pages.git.company.com/scm/hubble-data` if you have [subdomain isolation enabled](https://help.github.com/enterprise/2.1/admin/articles/configuring-dns-ssl-and-subdomain-settings/#enabling-subdomain-isolation)).

--- a/meta.tsv
+++ b/meta.tsv
@@ -1,0 +1,2 @@
+key	value
+schema-version	1

--- a/updater/reports/ReportPRUsage.py
+++ b/updater/reports/ReportPRUsage.py
@@ -1,3 +1,4 @@
+import calendar
 from .ReportDaily import *
 
 # Calculate percentage of active repositories with a least two contributors

--- a/updater/schema.py
+++ b/updater/schema.py
@@ -20,9 +20,11 @@ def checkSchemaVersion(dataDirectory):
 				if row[0] == "schema-version":
 					schemaVersionLocal = int(row[1])
 					break
-	except IOException as e:
+	except IOError:
 		print("error: the data repository has no file named meta.tsv", file = sys.stderr)
 		sys.exit(1)
+	except:
+		pass
 
 	if schemaVersionLocal < schemaVersion:
 		print("error: the data repository has an outdated scheme and needs to be migrated", file = sys.stderr)

--- a/updater/schema.py
+++ b/updater/schema.py
@@ -20,8 +20,9 @@ def checkSchemaVersion(dataDirectory):
 				if row[0] == "schema-version":
 					schemaVersionLocal = int(row[1])
 					break
-	except:
-		pass
+	except IOException as e:
+		print("error: the data repository has no file named meta.tsv", file = sys.stderr)
+		sys.exit(1)
 
 	if schemaVersionLocal < schemaVersion:
 		print("error: the data repository has an outdated scheme and needs to be migrated", file = sys.stderr)


### PR DESCRIPTION
added an example meta.tsv file that can be used for the hubble-data repository. Update the README.md to tell people that a meta.tsv file has to be present inside hubble-data. Added an Exception and print output in case there is no meta.tsv file. Fixed missing import statement in ReportPRUsage.py for calendar