### PR TITLE
Make table chart type explicit

### DIFF
--- a/docs/assets/js/charts.js
+++ b/docs/assets/js/charts.js
@@ -1070,6 +1070,11 @@ $(window).bind('load', function()
                     }
                 });
 
-            tables.each((index, table) => createTable(table));
+            tables.each(
+                function(index, table)
+                {
+                    if ($(table).attr('data-type') == 'table')
+                        createTable(table);
+                });
         });
 });

--- a/docs/housekeeping-abandoned-orgs.html
+++ b/docs/housekeeping-abandoned-orgs.html
@@ -52,5 +52,5 @@ permalink: /housekeeping-abandoned-orgs
 </div>
 
 <div class="chart-placeholder">
-	<table data-url="{{ site.dataURL }}/organizations-abandoned-detailed.tsv"></table>
+	<table data-url="{{ site.dataURL }}/organizations-abandoned-detailed.tsv" data-type="table"></table>
 </div>

--- a/docs/housekeeping-api-requests.html
+++ b/docs/housekeeping-api-requests.html
@@ -51,7 +51,7 @@ permalink: /housekeeping-api-requests
 </div>
 
 <div class="chart-placeholder">
-	<table data-url="{{ site.dataURL }}/api-requests-detailed.tsv"></table>
+	<table data-url="{{ site.dataURL }}/api-requests-detailed.tsv" data-type="table"></table>
 	<div class="info-box">
 		<p>
 			This table lists the resources requested via the API that accounted for the majority of API requests yesterday.

--- a/docs/housekeeping-forks.html
+++ b/docs/housekeeping-forks.html
@@ -59,5 +59,5 @@ permalink: /housekeeping-forks
 </div>
 
 <div class="chart-placeholder">
-	<table data-url="{{ site.dataURL }}/forks-to-organizations-detailed.tsv"></table>
+	<table data-url="{{ site.dataURL }}/forks-to-organizations-detailed.tsv" data-type="table"></table>
 </div>

--- a/docs/housekeeping-git-requests.html
+++ b/docs/housekeeping-git-requests.html
@@ -51,7 +51,7 @@ permalink: /housekeeping-git-requests
 </div>
 
 <div class="chart-placeholder">
-	<table data-url="{{ site.dataURL }}/git-requests-detailed.tsv"></table>
+	<table data-url="{{ site.dataURL }}/git-requests-detailed.tsv" data-type="table"></table>
 	<div class="info-box">
 		<p>
 			This table lists the repositories that accounted for the majority of Git requests yesterday.

--- a/docs/housekeeping-git-traffic.html
+++ b/docs/housekeeping-git-traffic.html
@@ -129,7 +129,7 @@ permalink: /housekeeping-git-traffic
 </div>
 
 <div class="chart-placeholder">
-	<table data-url="{{ site.dataURL }}/git-download-detailed.tsv"></table>
+	<table data-url="{{ site.dataURL }}/git-download-detailed.tsv" data-type="table"></table>
 	<div class="info-box">
 		<p>
 			This table lists the repositories that accounted for the majority of the traffic yesterday.

--- a/docs/housekeeping-repo-location.html
+++ b/docs/housekeeping-repo-location.html
@@ -51,5 +51,5 @@ permalink: /housekeeping-repo-location
 </div>
 
 <div class="chart-placeholder">
-	<table data-url="{{ site.dataURL }}/repositories-personal-nonowner-pushes-detailed.tsv"></table>
+	<table data-url="{{ site.dataURL }}/repositories-personal-nonowner-pushes-detailed.tsv" data-type="table"></table>
 </div>

--- a/docs/org-owners.html
+++ b/docs/org-owners.html
@@ -6,7 +6,7 @@ permalink: /org-owners
 
 <div class="chart-placeholder">
 	<h3>Organization Owners</h3>
-	<table data-url="{{ site.dataURL }}/org-owners.tsv"></table>
+	<table data-url="{{ site.dataURL }}/org-owners.tsv" data-type="table"></table>
 	<div class="info-box">
 		<p>Owners for each GitHub organization.</p>
 	</div>

--- a/docs/recommendations-legacy-teams.html
+++ b/docs/recommendations-legacy-teams.html
@@ -50,5 +50,5 @@ should be <a href="https://help.github.com/enterprise/2.11/user/articles/migrati
 </div>
 
 <div class="chart-placeholder">
-	<table data-url="{{ site.dataURL }}/teams-legacy-detailed.tsv"></table>
+	<table data-url="{{ site.dataURL }}/teams-legacy-detailed.tsv" data-type="table"></table>
 </div>

--- a/docs/recommendations-tokenless-auth.html
+++ b/docs/recommendations-tokenless-auth.html
@@ -58,5 +58,5 @@ permalink: /recommendations-tokenless-auth
 </div>
 
 <div class="chart-placeholder">
-	<table data-url="{{ site.dataURL }}/tokenless-authentication-detailed.tsv"></table>
+	<table data-url="{{ site.dataURL }}/tokenless-authentication-detailed.tsv" data-type="table"></table>
 </div>

--- a/docs/repos-activity.html
+++ b/docs/repos-activity.html
@@ -88,6 +88,7 @@ permalink: /repos-activity
 	<table
 		data-url="{{ site.dataURL }}/repository-activity-detailed.tsv"
 		data-config='{"slice": [0, 50]}'
+		data-type="table"
 	></table>
 	<div class="info-box">
 		<p>The top 50 most active repositories by number of pushes.</p>


### PR DESCRIPTION
This adds an explicit chart type declaration to all tables. The benefit of this is that this enables users to implement custom table types (with a distinct chart type) in extensions without clashing with Hubble’s own `table` type.