### PR TITLE
Add missing Python import directive

### DIFF
--- a/updater/reports/ReportPRUsage.py
+++ b/updater/reports/ReportPRUsage.py
@@ -1,3 +1,5 @@
+import calendar
+
 from .ReportDaily import *
 
 # Calculate percentage of active repositories with a least two contributors


### PR DESCRIPTION
I was now able to reproduce the issue of the missing `calendar` import that was mentioned in #136 and #146 by @IngoS11 and @primetheus.

I’m not entirely certain as to the reasons why the `calendar` module didn’t require an import before, but we’ll have to add the `import` statement anyway, because many users are probably affected.

So this adds the missing `import` directive.

Closes #136.