### PR TITLE
Support empty data repositories

### DIFF
--- a/updater/schema.py
+++ b/updater/schema.py
@@ -13,7 +13,13 @@ def checkSchemaVersion(dataDirectory):
 	schemaVersionLocal = 0
 
 	try:
-		with open(os.path.join(dataDirectory, "meta.tsv"), "r") as tsvFile:
+		metaFilePath = os.path.join(dataDirectory, "meta.tsv")
+
+		# If no meta.tsv has been created yet, no schema compatibility check is necessary
+		if not os.path.exists(metaFilePath):
+			return
+
+		with open(metaFilePath, "r") as tsvFile:
 			tsvReader = csv.reader(tsvFile, delimiter = "\t")
 
 			for row in tsvReader:


### PR DESCRIPTION
By accident, newly created data repositories didn’t work with the updater. The reason is that the updater checked the data schema version but failed, because no `meta.tsv` file (which contains the data schema version) was present.

This adds a check that, if the `meta.tsv` file is not yet present, simply succeeds with the update, through which the data repository is populated with an up-to-date schema anyway.

In contrast to #146, this allows users to get started with an empty repository instead of having to create a `meta.tsv` manually and reading through some more documentation.

Closes #145.