### PR TITLE
Show median values in aggregated charts by default

### DIFF
--- a/docs/housekeeping-abandoned-orgs.html
+++ b/docs/housekeeping-abandoned-orgs.html
@@ -24,7 +24,7 @@ permalink: /housekeeping-abandoned-orgs
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"slice": [0, 106],
 					"default": true
@@ -35,7 +35,7 @@ permalink: /housekeeping-abandoned-orgs
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					}
 				}
 			]

--- a/docs/housekeeping-forks.html
+++ b/docs/housekeeping-forks.html
@@ -24,7 +24,7 @@ permalink: /housekeeping-forks
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"slice": [0, 106],
 					"default": true
@@ -35,7 +35,7 @@ permalink: /housekeeping-forks
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					}
 				}
 			]

--- a/docs/housekeeping-repo-location.html
+++ b/docs/housekeeping-repo-location.html
@@ -24,7 +24,7 @@ permalink: /housekeeping-repo-location
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"slice": [0, 106],
 					"default": true
@@ -35,7 +35,7 @@ permalink: /housekeeping-repo-location
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					}
 				}
 			]

--- a/docs/orgs-activity.html
+++ b/docs/orgs-activity.html
@@ -34,7 +34,7 @@ permalink: /orgs-activity
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[
@@ -55,7 +55,7 @@ permalink: /orgs-activity
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[

--- a/docs/orgs-total.html
+++ b/docs/orgs-total.html
@@ -24,7 +24,7 @@ permalink: /orgs-total
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"slice": [0, 106],
 					"default": true
@@ -35,7 +35,7 @@ permalink: /orgs-total
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					}
 				}
 			]

--- a/docs/pr-usage.html
+++ b/docs/pr-usage.html
@@ -24,7 +24,7 @@ permalink: /pr-usage
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"slice": [0, 106],
 					"default": true
@@ -35,7 +35,7 @@ permalink: /pr-usage
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					}
 				}
 			]

--- a/docs/recommendations-legacy-teams.html
+++ b/docs/recommendations-legacy-teams.html
@@ -24,7 +24,7 @@ permalink: /recommendations-legacy-teams
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"slice": [0, 106],
 					"default": true
@@ -35,7 +35,7 @@ permalink: /recommendations-legacy-teams
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					}
 				}
 			]

--- a/docs/repos-activity.html
+++ b/docs/repos-activity.html
@@ -34,7 +34,7 @@ permalink: /repos-activity
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[
@@ -55,7 +55,7 @@ permalink: /repos-activity
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[
@@ -125,7 +125,7 @@ permalink: /repos-activity
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[
@@ -146,7 +146,7 @@ permalink: /repos-activity
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[

--- a/docs/repos-feature-usage.html
+++ b/docs/repos-feature-usage.html
@@ -24,7 +24,7 @@ permalink: /repos-feature-usage
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"slice": [0, 106],
 					"default": true
@@ -35,7 +35,7 @@ permalink: /repos-feature-usage
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					}
 				}
 			]

--- a/docs/repos-total.html
+++ b/docs/repos-total.html
@@ -34,7 +34,7 @@ permalink: /repos-total
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[
@@ -55,7 +55,7 @@ permalink: /repos-total
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[

--- a/docs/teams-total.html
+++ b/docs/teams-total.html
@@ -24,7 +24,7 @@ permalink: /teams-total
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"slice": [0, 106],
 					"default": true
@@ -35,7 +35,7 @@ permalink: /teams-total
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					}
 				}
 			]

--- a/docs/users-activity.html
+++ b/docs/users-activity.html
@@ -36,7 +36,7 @@ permalink: /users-activity
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[
@@ -59,7 +59,7 @@ permalink: /users-activity
 					"aggregate":
 					{
 						"period": "week",
-						"method": "first"
+						"method": "median"
 					},
 					"series":
 					[


### PR DESCRIPTION
This switches all charts with the `first` aggregation strategy to `median` aggregation.

Previously, chart views with aggregated data just showed the first value of each time period. The median value might be a better choice, because it is more representative of the data than just picking the first value
available. The arithmetic mean was also considered as a choice, but is expected not to even out sporadic effects such as public holidays as nicely as the median function.