### PR TITLE
ignore case when counting entities

### DIFF
--- a/updater/scripts/api-requests-by-user.sh
+++ b/updater/scripts/api-requests-by-user.sh
@@ -12,7 +12,7 @@ zcat -f /var/log/github/unicorn.log.1* |
     grep -oP 'current_user=\K\S+' |
     grep -Fvx 'nil' |
     sort |
-    uniq -c |
+    uniq -ic |
     sort -rn |
     head -20 |
     awk '{ printf("%s\t%s\n", $2, $1) }'

--- a/updater/scripts/api-requests.sh
+++ b/updater/scripts/api-requests.sh
@@ -8,6 +8,6 @@ zcat -f /var/log/haproxy.log.1* |
     perl -ne 'print if s/.*haproxy\[\d+\]: ([^:]+).*\/api\/v3\/([^\/\? ]+)\/([^\/\? ]+?(\/[^\/\? ]+)).*/\1 \2 \3/' |
     grep -v '^127.0.0.1' |
     sort |
-    uniq -c |
+    uniq -ic |
     sort -rn |
     awk '{printf("%s\t%s\t%s\t%s\n",$4,$3,$2,$1)}'

--- a/updater/scripts/git-requests.sh
+++ b/updater/scripts/git-requests.sh
@@ -7,6 +7,6 @@ echo -e "repository\tsource IP\trequests"
 zcat -f /var/log/babeld/babeld.log.1* |
     perl -ne 'print if s/.*ip=([^ ]+).*repo=([^ ]+).*/\1 \2/' |
     sort |
-    uniq -c |
+    uniq -ic |
     sort -rn |
     awk '{printf("%s\t%s\t%s\n",$3,$2,$1)}'

--- a/updater/scripts/git-versions.sh
+++ b/updater/scripts/git-versions.sh
@@ -10,5 +10,5 @@ zgrep -hF '||git/' /var/log/haproxy.log.1* |
 	uniq |
 	perl -lape 's/[^ ]+ //' |
 	sort -r -V |
-	uniq -c |
+	uniq -ic |
 	awk '{printf("%s\t%s\n",$2,$1)}'

--- a/updater/scripts/tokenless-auth.sh
+++ b/updater/scripts/tokenless-auth.sh
@@ -25,14 +25,14 @@ then
 		grep 'status=200' |
 		perl -ne 'print if s/^(?=.*member="?([^ "]+))(?=.*path=([^ ]+)\.git).*/\1 \2/' |
 		sort |
-		uniq -c |
+		uniq -ic |
 		sort -rn |
 		awk '{gsub(/[_.]/, "-", $2); printf("%s\t%s\t%s\n",$2,$3,$1)}'
 else
 	zcat -f /tmp/gitauth.log.1* |
 		perl -ne 'print if s/.*status=OK member="?([^ "]+) hashed_token=nil.*path=([^ ]+)\.git .*proto=http.*/\1 \2/' |
 		sort |
-		uniq -c |
+		uniq -ic |
 		sort -rn |
 		awk '{gsub(/[_.]/, "-", $2); printf("%s\t%s\t%s\n",$2,$3,$1)}'
 fi


### PR DESCRIPTION
Sometimes GHE entities (e.g. repo-, org-, team-, user-names) appear
with different casing in the log files. Ignore the casing when counting
these entities as they are generally case insensitive.