### PR TITLE
git-download: handle the case if there is no Git LFS traffic

### DIFF
--- a/updater/reports/ReportGitDownload.py
+++ b/updater/reports/ReportGitDownload.py
@@ -26,7 +26,7 @@ class ReportGitDownload(ReportDaily):
 				sum(map(lambda x: int(x[3] if len(x) > 2 and x[2] != "true" else 0), newData)),
 				sum(map(lambda x: int(x[4] if len(x) > 3 and x[2] == "true" else 0), newData)) // (1024 ** 3),
 				sum(map(lambda x: int(x[4] if len(x) > 3 and x[2] != "true" else 0), newData)) // (1024 ** 3),
-				int(sumLFSTraffic[0][0]) // (1024 ** 3),
+				int(sumLFSTraffic[0][0] if len(sumLFSTraffic) > 0 and len(sumLFSTraffic[0]) > 0 else 0) // (1024 ** 3),
 			])
 		self.detailedHeader[4] = "download [GB]"
 		self.detailedData = map(lambda x: [x[0], x[1], x[2], x[3], round(int(x[4]) / (1024 ** 3))], newData[:25])

--- a/updater/scripts/git-lfs-download.sh
+++ b/updater/scripts/git-lfs-download.sh
@@ -5,4 +5,4 @@
 
 echo "lfs traffic [B]"
 zcat -f /var/log/haproxy.log.1* |
-    LANG=C perl -ne '/\s200\s(\d+)\s-\s\-\s----\s.*GET (?:\/storage)?\/lfs\/\d+\// && {$traffic += $1}; END {print $traffic}'
+    LANG=C perl -ne 'use bigint; /\s200\s(\d+)\s-\s\-\s----\s.*GET (?:\/storage)?\/lfs\/\d+\// && {$traffic += $1}; END {print ($traffic+0)}'


### PR DESCRIPTION
If there was no Git LFS traffic in the logs, then a user would see this
error:

```
    File "hubble/updater/reports/ReportGitDownload.py", line 29, in updateDailyData
        int(sumLFSTraffic[0][0]) // (1024 ** 3),
    IndexError: list index out of range
```

Handle this case and report no Git LFS traffic properly.

---

While at it, I also made it work for *very* large Git LFS download number:

By default Perl uses scientific integer notation (e.g 2e+19) for very 
large integer numbers. The Python code would choke on it:

    ValueError: invalid literal for int() with base 10: '2e+19'

Fix this by teaching Perl to always print the download number in
decimal form.