### PR TITLE
Replace deprecated Chart.js configuration option

### DIFF
--- a/docs/assets/js/_partials/chart-history.js
+++ b/docs/assets/js/_partials/chart-history.js
@@ -8,7 +8,7 @@ const timeSeriesChartDefaults =
                 type: 'time',
                 time:
                 {
-                    format: 'YYYY-MM-DD',
+                    parser: 'YYYY-MM-DD',
                     tooltipFormat: 'D MMM YYYY',
                     minUnit: 'day',
                 }


### PR DESCRIPTION
The history chart uses the `options.time.format` option to specify the date format of the *x* axis. [Chart.js deprecated this option](https://github.com/chartjs/Chart.js/blob/f815dd51968a0bec9305e1cf14d738d6f23c93aa/src/scales/scale.time.js#L454) in favor of the new option `options.time.parser`, which leads to warnings on the web console.

This pull request replaces the deprecated option with its successor.