### PR TITLE
Add a view for failed webhooks

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -55,6 +55,8 @@
       url: "/housekeeping-repo-location"
     - title: "Forks"
       url: "/housekeeping-forks"
+    - title: "Failed Webhooks"
+      url: "/housekeeping-failed-webhooks"
 - title: "Recommendations"
   url: "/recommendations-tokenless-auth"
   subnavigation:

--- a/docs/demo-data/failed-webhooks-detailed.tsv
+++ b/docs/demo-data/failed-webhooks-detailed.tsv
@@ -1,0 +1,5 @@
+hook_id	type	host	message	count
+1	business	10.0.0.1	request timed out	3
+2	integration	10.0.0.2	Couldn't connect to server	2
+3	repository	10.0.0.3	Couldn't connect to server	1
+4	organization	10.0.0.4	Couldn't resolve host name	1

--- a/docs/demo-data/failed-webhooks.tsv
+++ b/docs/demo-data/failed-webhooks.tsv
@@ -1,0 +1,5 @@
+hook_id	type	host	message
+1	business	10.0.0.1	request timed out
+2	integration	10.0.0.2	Couldn't connect to server
+3	repository	10.0.0.3	Couldn't connect to server
+4	organization	10.0.0.4	Couldn't resolve host name

--- a/docs/demo-data/failed-webhooks.tsv
+++ b/docs/demo-data/failed-webhooks.tsv
@@ -1,5 +1,7 @@
-hook_id	type	host	message
-1	business	10.0.0.1	request timed out
-2	integration	10.0.0.2	Couldn't connect to server
-3	repository	10.0.0.3	Couldn't connect to server
-4	organization	10.0.0.4	Couldn't resolve host name
+date	failed webhooks
+2020-10-01	0
+2020-10-02	1
+2020-10-03	5
+2020-10-04	7
+2020-10-05	5
+2020-10-06	4

--- a/docs/housekeeping-failed-webhooks.html
+++ b/docs/housekeeping-failed-webhooks.html
@@ -5,7 +5,46 @@ permalink: /housekeeping-failed-webhooks
 ---
 
 <div class="chart-placeholder">
-  <table data-url="{{ site.dataURL }}/failed-webhooks.tsv" data-type="table"></table>
+	<h3>Failed Webhooks</h3>
+	<canvas
+		data-url="{{ site.dataURL }}/failed-webhooks.tsv"
+		data-type="history"
+		data-config='{
+			"views":
+			[
+				{
+					"label": "2 m",
+					"tooltip": "Show the last 2 months",
+					"aggregate": false,
+					"slice": [0, 61],
+					"default": true
+				},
+				{
+					"label": "2 y",
+					"tooltip": "Show the last 2 years",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					},
+					"slice": [0, 106]
+				},
+				{
+					"label": "all",
+					"tooltip": "Show all data",
+					"aggregate":
+					{
+						"period": "week",
+						"method": "sum"
+					}
+				}
+			]
+    }'></canvas>
+	<div class="info-box"></div>
+</div>
+
+<div class="chart-placeholder">
+  <table data-url="{{ site.dataURL }}/failed-webhooks-detailed.tsv" data-type="table"></table>
 
 	<div class="info-box">
 		<p>

--- a/docs/housekeeping-failed-webhooks.html
+++ b/docs/housekeeping-failed-webhooks.html
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Failed Webhooks
+permalink: /housekeeping-failed-webhooks
+---
+
+<div class="chart-placeholder">
+  <table data-url="{{ site.dataURL }}/failed-webhooks.tsv" data-type="table"></table>
+
+	<div class="info-box">
+		<p>
+			<ul>
+        <li><code>business</code> a <a href="https://docs.github.com/enterprise-server/admin/user-management/managing-global-webhooks">global webhook</a></li>
+        <li><code>integration</code> a <a href="https://docs.github.com/enterprise-server/developers/apps/getting-started-with-apps">GitHub App</a> webhook URL</li>
+        <li><code>repository</code> an <a href="https://docs.github.com/enterprise-server/rest/reference/repos#webhooks">repository hook</a></li>
+        <li><code>organization</code> an <a href="https://docs.github.com/enterprise-server/rest/reference/orgs#webhooks">organization hook</a></li>
+      </ul>
+		</p>
+	</div>
+</div>
+
+
+

--- a/updater/reports/ReportFailedWebhooks.py
+++ b/updater/reports/ReportFailedWebhooks.py
@@ -8,7 +8,7 @@ class ReportFailedWebhooks(ReportDaily):
 	def readData(self):
 		pass
 
-	def updateData(self):
+	def updateDailyData(self):
 		self.detailedHeader, self.detailedData = self.parseData(
 			self.executeScript(self.scriptPath("failed-webhooks.sh")))
 		self.header = ["date", "failed webhooks"]

--- a/updater/reports/ReportFailedWebhooks.py
+++ b/updater/reports/ReportFailedWebhooks.py
@@ -1,0 +1,17 @@
+from .ReportDaily import *
+
+# Report how many webhooks failed
+class ReportFailedWebhooks(ReportDaily):
+	def name(self):
+		return "failed-webhooks"
+
+	def readData(self):
+		pass
+
+	def updateData(self):
+		self.detailedHeader, self.detailedData = self.parseData(
+			self.executeScript(self.scriptPath("failed-webhooks.sh")))
+		self.header = ["date", "failed webhooks"]
+		self.data.append([str(self.yesterday()), len(self.detailedData)])
+		self.truncateData(self.timeRangeTotal())
+		self.sortDataByDate()

--- a/updater/reports/ReportFailedWebhooks.py
+++ b/updater/reports/ReportFailedWebhooks.py
@@ -5,9 +5,6 @@ class ReportFailedWebhooks(ReportDaily):
 	def name(self):
 		return "failed-webhooks"
 
-	def readData(self):
-		pass
-
 	def updateDailyData(self):
 		self.detailedHeader, self.detailedData = self.parseData(
 			self.executeScript(self.scriptPath("failed-webhooks.sh")))

--- a/updater/reports/ReportFailedWebhooks.py
+++ b/updater/reports/ReportFailedWebhooks.py
@@ -6,9 +6,14 @@ class ReportFailedWebhooks(ReportDaily):
 		return "failed-webhooks"
 
 	def updateDailyData(self):
-		self.detailedHeader, self.detailedData = self.parseData(
+		self.detailedHeader, newData = self.parseData(
 			self.executeScript(self.scriptPath("failed-webhooks.sh")))
 		self.header = ["date", "failed webhooks"]
-		self.data.append([str(self.yesterday()), len(self.detailedData)])
+		self.data.append(
+			[
+				str(self.yesterday()),
+				sum(map(lambda x: int(x[4] if len(x) > 3 else 0), newData)),
+			])
+		self.detailedData = newData[:25]
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/scripts/failed-webhooks.sh
+++ b/updater/scripts/failed-webhooks.sh
@@ -12,15 +12,8 @@ zcat -f /var/log/hookshot/exceptions.log.1* |
   # remove this part as it's not real JSON and breaks the remaining chain
   sed -e 's/{\\"url[^}]*}, //' |
   # this can probably be done more elegantly
-  jq --slurp '.[] | {id: .id, url: .url, type: (.data|tostring|fromjson)[0], msg: .msg}' |
-  jq --slurp -c '.[] | [.id,.url,.type,.msg]' |
+  jq -r -c --slurp '.[] | "\(.id)\t\((.data|tostring|fromjson)[0])\t\(.url)\t\(.msg)"' |
   sort |
   uniq -ic |
   sort -rn |
-  awk -F [ '{printf("%s,%s\n", $2,$1)}' |
-  awk -F, '{
-    gsub(/(\[|\]|\")/, "");
-    gsub(/-[0-9]+/, "", $3);
-    gsub(/ /, "", $5);
-    printf("%s\t%s\t%s\t%s\t%s\n",$1,$3,$2,$4,$5)
-  }'
+   perl -pne 's/([0-9]+)\s(.*)/\2\t\1/'

--- a/updater/scripts/failed-webhooks.sh
+++ b/updater/scripts/failed-webhooks.sh
@@ -12,8 +12,8 @@ zcat -f /var/log/hookshot/exceptions.log.1* |
   # remove this part as it's not real JSON and breaks the remaining chain
   sed -e 's/{\\"url[^}]*}, //' |
   # this can probably be done more elegantly
-  jq -r -c --slurp '.[] | "\(.id)\t\((.data|tostring|fromjson)[0])\t\(.url)\t\(.msg)"' |
+  jq -r -c --slurp '.[] | "\(.id)\t\((.data|tostring|fromjson)[0] | sub("-[0-9]+"; ""))\t\(.url)\t\(.msg)"' |
   sort |
   uniq -ic |
   sort -rn |
-   perl -pne 's/([0-9]+)\s(.*)/\2\t\1/'
+  perl -pne 's/([0-9]+)\s(.*)/\2\t\1/'

--- a/updater/scripts/failed-webhooks.sh
+++ b/updater/scripts/failed-webhooks.sh
@@ -4,19 +4,23 @@
 # List failed webhooks
 #
 
-echo -e "hook_id\ttype\thost\tmessage"
+echo -e "hook_id\ttype\thost\tmessage\tcount"
 
 zcat -f /var/log/hookshot/exceptions.log.1* |
   jq --slurp '.[] | del(.backtrace) | {hook_id,service_host,message,class,parent}' |
-  jq --slurp -c 'unique_by(.hook_id,.service_host,.class) | sort_by(.hook_id) | .[] | {id: .hook_id,url: .service_host, data: (.parent|tostring), msg: .message}' |
+  jq --slurp -c 'sort_by(.hook_id) | .[] | {id: .hook_id,url: .service_host, data: (.parent|tostring), msg: .message}' |
   # remove this part as it's not real JSON and breaks the remaining chain
-  sed -E 's/{\\\"url\\\"=>\\\"(.*)\\\"\}, //g' |
+  sed -e 's/{\\"url[^}]*}, //' |
   # this can probably be done more elegantly
   jq --slurp '.[] | {id: .id, url: .url, type: (.data|tostring|fromjson)[0], msg: .msg}' |
   jq --slurp -c '.[] | [.id,.url,.type,.msg]' |
+  sort |
+  uniq -ic |
+  sort -rn |
+  awk -F [ '{printf("%s,%s\n", $2,$1)}' |
   awk -F, '{
     gsub(/(\[|\]|\")/, "");
     gsub(/-[0-9]+/, "", $3);
-    printf("%s\t%s\t%s\t%s\n",$1,$3,$2,$4)
+    gsub(/ /, "", $5);
+    printf("%s\t%s\t%s\t%s\t%s\n",$1,$3,$2,$4,$5)
   }'
-

--- a/updater/scripts/failed-webhooks.sh
+++ b/updater/scripts/failed-webhooks.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#
+# List failed webhooks
+#
+
+echo -e "hook_id\ttype\thost\tmessage"
+
+zcat -f /var/log/hookshot/exceptions.log.1* |
+  jq --slurp '.[] | del(.backtrace) | {hook_id,service_host,message,class,parent}' |
+  jq --slurp -c 'unique_by(.hook_id,.service_host,.class) | sort_by(.hook_id) | .[] | {id: .hook_id,url: .service_host, data: (.parent|tostring), msg: .message}' |
+  # remove this part as it's not real JSON and breaks the remaining chain
+  sed -E 's/{\\\"url\\\"=>\\\"(.*)\\\"\}, //g' |
+  # this can probably be done more elegantly
+  jq --slurp '.[] | {id: .id, url: .url, type: (.data|tostring|fromjson)[0], msg: .msg}' |
+  jq --slurp -c '.[] | [.id,.url,.type,.msg]' |
+  awk -F, '{
+    gsub(/(\[|\]|\")/, "");
+    gsub(/-[0-9]+/, "", $3);
+    printf("%s\t%s\t%s\t%s\n",$1,$3,$2,$4)
+  }'
+

--- a/updater/update-stats.py
+++ b/updater/update-stats.py
@@ -12,6 +12,7 @@ from reports.ReportAPIRequests import *
 from reports.ReportAPIRequestsByUser import *
 from reports.ReportContributorsByOrg import *
 from reports.ReportContributorsByRepo import *
+from reports.ReportFailedWebhooks import *
 from reports.ReportForksToOrgs import *
 from reports.ReportGitDownload import *
 from reports.ReportGitProtocol import *
@@ -80,6 +81,7 @@ def main():
 	ReportAPIRequestsByUser(configuration, dataDirectory, metaStats).update()
 	ReportContributorsByOrg(configuration, dataDirectory, metaStats).update()
 	ReportContributorsByRepo(configuration, dataDirectory, metaStats).update()
+	ReportFailedWebhooks(configuration, dataDirectory, metaStats).update()
 	ReportForksToOrgs(configuration, dataDirectory, metaStats).update()
 	ReportGitDownload(configuration, dataDirectory, metaStats).update()
 	ReportGitProtocol(configuration, dataDirectory, metaStats).update()


### PR DESCRIPTION
## Description

Add a view to display failed webhooks.
This can help to identify webhooks that are "clogging up" the `hookshots` queue and could safely be disabled, e.g. using `ghe-webhook-manage -d 1` on the management console.

```sh
$ ghe-webhook-manage 
Usage: ghe-webhook-manage [options] [hook_id]

Manage webhook status and locate where a hook is configured


OPTIONS:
 -h              Show this message.
 -s              Lookup a webhook's information (target, url, active status)
 -e              Enable a webhook
 -d              Disable a webhook
```

## Demo

1. Open Hubble
2. Go to Housekeeping > Failed Webhooks: `/housekeeping-failed-webhooks`

## Screenshots

![hubble failed webhooks](https://user-images.githubusercontent.com/203805/94921451-a72a6880-04b8-11eb-980e-627cc830ddec.png)
