### PR TITLE
warn user about incorrect traffic and versions numbers with active replicas

### DIFF
--- a/docs/housekeeping-git-traffic.html
+++ b/docs/housekeeping-git-traffic.html
@@ -64,6 +64,9 @@ permalink: /housekeeping-git-traffic
 		<p>
 			High numbers of clone operations usually indicate an unfavorably configured CI process.
 		</p>
+		<p>
+			Attention: These numbers are likely incorrect on a configuration with active replicas.
+		</p>
 	</div>
 </div>
 

--- a/docs/users-git-versions.html
+++ b/docs/users-git-versions.html
@@ -11,6 +11,9 @@ permalink: /users-git-versions
 		<p>
 			Shows how many users connected with recommended, outdated, and vulnerable Git clients.
 		</p>
+		<p>
+			Attention: These numbers are likely incorrect on a configuration with active replicas.
+		</p>
 	</div>
 	<div class="info-box">
 		<p>


### PR DESCRIPTION
`/var/log/github-audit.log` is used to query traffic and version info.
These log files are written on the node that serves the traffic and
Hubble only queries the log file on the primary. Therefore, in a configuration
with active replicas we are not reporting the right numbers.

Warn the user about it until we fix this.