### PR TITLE
Fixing GHES 3.0 Compatibility

### DIFF
--- a/updater/scripts/failed-webhooks.sh
+++ b/updater/scripts/failed-webhooks.sh
@@ -6,7 +6,7 @@
 
 echo -e "hook_id\ttype\thost\tmessage\tcount"
 
-zcat -f /var/log/hookshot/exceptions.log.1* |
+zcat -f /var/log/github/exceptions.log.1* |
   jq --slurp '.[] | del(.backtrace) | {hook_id,service_host,message,class,parent}' |
   jq --slurp -c 'sort_by(.hook_id) | .[] | {id: .hook_id,url: .service_host, data: (.parent|tostring), msg: .message}' |
   # remove this part as it's not real JSON and breaks the remaining chain

--- a/updater/scripts/git-protocol.sh
+++ b/updater/scripts/git-protocol.sh
@@ -4,7 +4,7 @@
 #
 echo -e "Git protocol\tconnections"
 
-zcat -f /var/log/babeld/babeld.log.1* |
+zcat -f /var/log/syslog.1* |
 	perl -ne 'print if s/.*proto=([^ ]+).*op done.*/\1/' |
 	sort |
 	uniq -c |

--- a/updater/scripts/git-protocol.sh
+++ b/updater/scripts/git-protocol.sh
@@ -4,7 +4,25 @@
 #
 echo -e "Git protocol\tconnections"
 
-zcat -f /var/log/syslog.1* |
+function ghe_greater_equal () {
+    cat /etc/github/enterprise-release |
+        perl -sne '
+            use version;
+            my ($installed) = $_ =~ /RELEASE_VERSION="([0-9]+([.][0-9]+)+)"/;
+            exit (version->parse($installed) lt version->parse($required));
+        ' -- -required="$1"
+    return $?
+}
+
+if ghe_greater_equal "3.0.0"; then
+    # check yesterday's log file post 3.0.0
+    CAT_LOG_FILE="zcat -f /var/log/syslog.1* | grep babeld"
+else
+    # check yesterday's log file pre 3.0.0
+    CAT_LOG_FILE="zcat -f /var/log/babeld/babeld.log.1*"
+fi
+
+eval "${CAT_LOG_FILE}" |
 	perl -ne 'print if s/.*proto=([^ ]+).*op done.*/\1/' |
 	sort |
 	uniq -c |

--- a/updater/scripts/git-requests.sh
+++ b/updater/scripts/git-requests.sh
@@ -4,7 +4,7 @@
 #
 echo -e "repository\tsource IP\trequests"
 
-zcat -f /var/log/babeld/babeld.log.1* |
+zcat -f /var/log/syslog.1* |
     perl -ne 'print if s/.*ip=([^ ]+).*repo=([^ ]+).*/\1 \2/' |
     sort |
     uniq -ic |


### PR DESCRIPTION
GitHub uses containerization of more services on version 3.0 as opposed to version 2.22. That means containers use the journald log driver and logs are available via journalctl, rather than the usual log location on disk as they used to be in the past. This may be affecting 3rd party's tool log parsing logic.