### PR TITLE
Add GHES 3.x compatibility with fixed `ghe-console` based reports

### DIFF
--- a/updater/reports/Report.py
+++ b/updater/reports/Report.py
@@ -71,8 +71,8 @@ class Report(object):
 						stdin = f.read()
 				except:
 					# If the script is a list of strings, then escape the content and set it to stdin
-					stdin = " ".join(map(lambda x: '"' + x.replace('\\"', '\\\\"').replace('"', '\\"') + '"', script))
-				script = ["bash -s", "--"]
+					stdin = " ".join(script)
+				script = ["bash", "-s", "--"]
 
 			# Execute the script via SSH
 			script = [

--- a/updater/scripts/failed-webhooks.sh
+++ b/updater/scripts/failed-webhooks.sh
@@ -6,14 +6,37 @@
 
 echo -e "hook_id\ttype\thost\tmessage\tcount"
 
-zcat -f /var/log/hookshot/exceptions.log.1* |
-  jq --slurp '.[] | del(.backtrace) | {hook_id,service_host,message,class,parent}' |
-  jq --slurp -c 'sort_by(.hook_id) | .[] | {id: .hook_id,url: .service_host, data: (.parent|tostring), msg: .message}' |
-  # remove this part as it's not real JSON and breaks the remaining chain
-  sed -e 's/{\\"url[^}]*}, //' |
-  # this can probably be done more elegantly
-  jq -r -c --slurp '.[] | "\(.id)\t\((.data|tostring|fromjson)[0] | sub("-[0-9]+"; ""))\t\(.url)\t\(.msg)"' |
-  sort |
-  uniq -ic |
-  sort -rn |
-  perl -pne 's/([0-9]+)\s(.*)/\2\t\1/'
+function ghe_greater_equal () {
+    cat /etc/github/enterprise-release |
+        perl -sne '
+            use version;
+            my ($installed) = $_ =~ /RELEASE_VERSION="([0-9]+([.][0-9]+)+)"/;
+            exit (version->parse($installed) lt version->parse($required));
+        ' -- -required="$1"
+    return $?
+}
+
+if ghe_greater_equal "3.0.0"; then
+    # check yesterday's log file post 3.0.0
+    zcat -f /var/log/syslog.1* | grep hookshot-go |
+        grep 'hook_id=[^ ]' |
+        grep -v 'status=200' |
+        perl -ne 'print if s/.*parent=([^ ]+)-.*hook_id=([^ ]+).*dest_url=([^ ]+).*public_error_message="(.*)".*/\2\t\1\t\3\t\4/' |
+        sort |
+        uniq -ic |
+        sort -rn |
+        perl -pne 's/([0-9]+)\s(.*)/\2\t\1/'
+else
+    # check yesterday's log file pre 3.0.0
+    zcat -f /var/log/hookshot/exceptions.log.1* |
+        jq --slurp '.[] | del(.backtrace) | {hook_id,service_host,message,class,parent}' |
+        jq --slurp -c 'sort_by(.hook_id) | .[] | {id: .hook_id,url: .service_host, data: (.parent|tostring), msg: .message}' |
+        # remove this part as it's not real JSON and breaks the remaining chain
+        sed -e 's/{\\"url[^}]*}, //' |
+        # this can probably be done more elegantly
+        jq -r -c --slurp '.[] | "\(.id)\t\((.data|tostring|fromjson)[0] | sub("-[0-9]+"; ""))\t\(.url)\t\(.msg)"' |
+        sort |
+        uniq -ic |
+        sort -rn |
+        perl -pne 's/([0-9]+)\s(.*)/\2\t\1/'
+fi

--- a/updater/scripts/git-protocol.sh
+++ b/updater/scripts/git-protocol.sh
@@ -4,8 +4,26 @@
 #
 echo -e "Git protocol\tconnections"
 
-zcat -f /var/log/babeld/babeld.log.1* |
-	perl -ne 'print if s/.*proto=([^ ]+).*op done.*/\1/' |
-	sort |
-	uniq -c |
-	awk '{printf("%s\t%s\n",$2,$1)}'
+function ghe_greater_equal () {
+    cat /etc/github/enterprise-release |
+        perl -sne '
+            use version;
+            my ($installed) = $_ =~ /RELEASE_VERSION="([0-9]+([.][0-9]+)+)"/;
+            exit (version->parse($installed) lt version->parse($required));
+        ' -- -required="$1"
+    return $?
+}
+
+if ghe_greater_equal "3.0.0"; then
+    # check yesterday's log file post 3.0.0
+    CAT_LOG_FILE="zcat -f /var/log/syslog.1* | grep babeld"
+else
+    # check yesterday's log file pre 3.0.0
+    CAT_LOG_FILE="zcat -f /var/log/babeld/babeld.log.1*"
+fi
+
+eval "${CAT_LOG_FILE}" |
+    perl -ne 'print if s/.*proto=([^ ]+).*op done.*/\1/' |
+    sort |
+    uniq -c |
+    awk '{printf("%s\t%s\n",$2,$1)}'

--- a/updater/scripts/git-requests.sh
+++ b/updater/scripts/git-requests.sh
@@ -4,7 +4,25 @@
 #
 echo -e "repository\tsource IP\trequests"
 
-zcat -f /var/log/babeld/babeld.log.1* |
+function ghe_greater_equal () {
+    cat /etc/github/enterprise-release |
+        perl -sne '
+            use version;
+            my ($installed) = $_ =~ /RELEASE_VERSION="([0-9]+([.][0-9]+)+)"/;
+            exit (version->parse($installed) lt version->parse($required));
+        ' -- -required="$1"
+    return $?
+}
+
+if ghe_greater_equal "3.0.0"; then
+    # check yesterday's log file post 3.0.0
+    CAT_LOG_FILE="zcat -f /var/log/syslog.1* | grep babeld"
+else
+    # check yesterday's log file pre 3.0.0
+    CAT_LOG_FILE="zcat -f /var/log/babeld/babeld.log.1*"
+fi
+
+eval "${CAT_LOG_FILE}" |
     perl -ne 'print if s/.*ip=([^ ]+).*repo=([^ ]+).*/\1 \2/' |
     sort |
     uniq -ic |


### PR DESCRIPTION
- This PR is inspired by  #235 and my previous PR #228. 
- Fixing the issue with reports based on `ghe-console` which executes code directly in `rails console`.  The issue was caused by improper/incompatible script code escaping. 
