### PR TITLE
Separate command arguments from name

### DIFF
--- a/updater/reports/Report.py
+++ b/updater/reports/Report.py
@@ -72,7 +72,7 @@ class Report(object):
 				except:
 					# If the script is a list of strings, then escape the content and set it to stdin
 					stdin = " ".join(map(lambda x: '"' + x.replace('\\"', '\\\\"').replace('"', '\\"') + '"', script))
-				script = ["bash -s", "--"]
+				script = ["bash", "-s", "--"]
 
 			# Execute the script via SSH
 			script = [


### PR DESCRIPTION
In order to execute commands, `subprocess.Popen` expects a list of strings, where the first one represents the name of the command and the remaining strings are the command’s arguments. However, the `-s` option was included in the name of the binary, which isn’t supported in newer versions of Python anymore.