### PR TITLE
Refactor functions for server calls

### DIFF
--- a/updater/reports/Report.py
+++ b/updater/reports/Report.py
@@ -89,7 +89,7 @@ class Report(object):
 
 		return stdout
 
-	def executeGHEConsole(self, script):
+	def executeRubyScriptOnServer(self, script):
 		# Escape the Ruby script, as it is going to be sent as a string on the command line
 		script = script.replace('\\t', '\\\\t').replace('\\n', '\\\\n')
 

--- a/updater/reports/Report.py
+++ b/updater/reports/Report.py
@@ -67,7 +67,7 @@ class Report(object):
 			if not stdin:
 				try:
 					# If the script is a file, then read its content as-is into stdin
-					with open(script) as f:
+					with open(self.scriptPath(script)) as f:
 						stdin = f.read()
 				except:
 					# If the script is a list of strings, then escape the content and set it to stdin

--- a/updater/reports/Report.py
+++ b/updater/reports/Report.py
@@ -96,7 +96,7 @@ class Report(object):
 		)
 
 	# Executes a database query, given as a string
-	def executeQuery(self, query):
+	def executeDatabaseQueryOnServer(self, query):
 		return self.executeScript(self.configuration["databaseCommand"], stdin = query)
 
 	# Helper function to parse a TSV file into a data array

--- a/updater/reports/Report.py
+++ b/updater/reports/Report.py
@@ -89,11 +89,13 @@ class Report(object):
 
 		return stdout
 
-	def executeGHEConsole(self, rubyCode):
-		escapedRubyCode = rubyCode.replace('\\t', '\\\\t').replace('\\n', '\\\\n')
-		return self.executeScript(
-			["github-env", "bin/runner", "-e", "production", "'" + escapedRubyCode + "'"]
-		)
+	def executeGHEConsole(self, script):
+		# Escape the Ruby script, as it is going to be sent as a string on the command line
+		script = script.replace('\\t', '\\\\t').replace('\\n', '\\\\n')
+
+		command = ["github-env", "bin/runner", "-e", "production", "'" + script + "'"]
+
+		return self.executeScript(command)
 
 	# Executes a database query, given as a string
 	def executeDatabaseQueryOnServer(self, query):

--- a/updater/reports/ReportAPIRequests.py
+++ b/updater/reports/ReportAPIRequests.py
@@ -6,7 +6,8 @@ class ReportAPIRequests(ReportDaily):
 		return "api-requests"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(self.executeScript("api-requests.sh"))
+		self.detailedHeader, newData = self.parseData(
+			self.executeBashScriptOnServer("api-requests.sh"))
 		self.header = ["date", "API requests"]
 		self.data.append(
 			[

--- a/updater/reports/ReportAPIRequests.py
+++ b/updater/reports/ReportAPIRequests.py
@@ -6,8 +6,7 @@ class ReportAPIRequests(ReportDaily):
 		return "api-requests"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("api-requests.sh")))
+		self.detailedHeader, newData = self.parseData(self.executeScript("api-requests.sh"))
 		self.header = ["date", "API requests"]
 		self.data.append(
 			[

--- a/updater/reports/ReportAPIRequestsByUser.py
+++ b/updater/reports/ReportAPIRequestsByUser.py
@@ -10,4 +10,5 @@ class ReportAPIRequestsByUser(Report):
 		pass
 
 	def updateData(self):
-		self.header, self.data = self.parseData(self.executeScript("api-requests-by-user.sh"))
+		self.header, self.data = self.parseData(
+			self.executeBashScriptOnServer("api-requests-by-user.sh"))

--- a/updater/reports/ReportAPIRequestsByUser.py
+++ b/updater/reports/ReportAPIRequestsByUser.py
@@ -10,5 +10,4 @@ class ReportAPIRequestsByUser(Report):
 		pass
 
 	def updateData(self):
-		self.header, self.data = self.parseData(
-			self.executeScript(self.scriptPath("api-requests-by-user.sh")))
+		self.header, self.data = self.parseData(self.executeScript("api-requests-by-user.sh"))

--- a/updater/reports/ReportContributorsByOrg.py
+++ b/updater/reports/ReportContributorsByOrg.py
@@ -12,7 +12,7 @@ class ReportContributorsByOrg(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])))
+			self.executeDatabaseQueryOnServer(self.query([self.daysAgo(30), self.yesterday()])))
 
 	# Collects the number of contributors per organization
 	def query(self, timeRange):

--- a/updater/reports/ReportContributorsByRepo.py
+++ b/updater/reports/ReportContributorsByRepo.py
@@ -12,7 +12,7 @@ class ReportContributorsByRepo(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])))
+			self.executeDatabaseQueryOnServer(self.query([self.daysAgo(30), self.yesterday()])))
 
 	# Collects the number of contributors per repository
 	def query(self, timeRange):

--- a/updater/reports/ReportFailedWebhooks.py
+++ b/updater/reports/ReportFailedWebhooks.py
@@ -6,7 +6,8 @@ class ReportFailedWebhooks(ReportDaily):
 		return "failed-webhooks"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(self.executeScript("failed-webhooks.sh"))
+		self.detailedHeader, newData = self.parseData(
+			self.executeBashScriptOnServer("failed-webhooks.sh"))
 		self.header = ["date", "failed webhooks"]
 		self.data.append(
 			[

--- a/updater/reports/ReportFailedWebhooks.py
+++ b/updater/reports/ReportFailedWebhooks.py
@@ -6,8 +6,7 @@ class ReportFailedWebhooks(ReportDaily):
 		return "failed-webhooks"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("failed-webhooks.sh")))
+		self.detailedHeader, newData = self.parseData(self.executeScript("failed-webhooks.sh"))
 		self.header = ["date", "failed webhooks"]
 		self.data.append(
 			[

--- a/updater/reports/ReportForksToOrgs.py
+++ b/updater/reports/ReportForksToOrgs.py
@@ -10,7 +10,7 @@ class ReportForksToOrgs(ReportDaily):
 		return "forks-to-organizations"
 
 	def updateDailyData(self):
-		self.detailedHeader, self.detailedData = self.parseData(self.executeQuery(self.query()))
+		self.detailedHeader, self.detailedData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.header = ["date", "forks to organizations"]
 		self.data.append([str(self.yesterday()), len(self.detailedData)])
 		self.truncateData(self.timeRangeTotal())

--- a/updater/reports/ReportGitDownload.py
+++ b/updater/reports/ReportGitDownload.py
@@ -6,8 +6,9 @@ class ReportGitDownload(ReportDaily):
 		return "git-download"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(self.executeScript("git-download.sh"))
-		_, sumLFSTraffic = self.parseData(self.executeScript("git-lfs-download.sh"))
+		self.detailedHeader, newData = self.parseData(
+			self.executeBashScriptOnServer("git-download.sh"))
+		_, sumLFSTraffic = self.parseData(self.executeBashScriptOnServer("git-lfs-download.sh"))
 		self.header = \
 			[
 				"date",

--- a/updater/reports/ReportGitDownload.py
+++ b/updater/reports/ReportGitDownload.py
@@ -6,10 +6,8 @@ class ReportGitDownload(ReportDaily):
 		return "git-download"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("git-download.sh")))
-		_, sumLFSTraffic = self.parseData(
-			self.executeScript(self.scriptPath("git-lfs-download.sh")))
+		self.detailedHeader, newData = self.parseData(self.executeScript("git-download.sh"))
+		_, sumLFSTraffic = self.parseData(self.executeScript("git-lfs-download.sh"))
 		self.header = \
 			[
 				"date",

--- a/updater/reports/ReportGitProtocol.py
+++ b/updater/reports/ReportGitProtocol.py
@@ -6,8 +6,7 @@ class ReportGitProtocol(ReportDaily):
 		return "git-protocol"
 
 	def updateDailyData(self):
-		_, items = self.parseData(
-			self.executeScript(self.scriptPath("git-protocol.sh")))
+		_, items = self.parseData(self.executeScript("git-protocol.sh"))
 
 		protocols = {}
 		for item in items:

--- a/updater/reports/ReportGitProtocol.py
+++ b/updater/reports/ReportGitProtocol.py
@@ -6,7 +6,7 @@ class ReportGitProtocol(ReportDaily):
 		return "git-protocol"
 
 	def updateDailyData(self):
-		_, items = self.parseData(self.executeScript("git-protocol.sh"))
+		_, items = self.parseData(self.executeBashScriptOnServer("git-protocol.sh"))
 
 		protocols = {}
 		for item in items:

--- a/updater/reports/ReportGitRequests.py
+++ b/updater/reports/ReportGitRequests.py
@@ -6,7 +6,8 @@ class ReportGitRequests(ReportDaily):
 		return "git-requests"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(self.executeScript("git-requests.sh"))
+		self.detailedHeader, newData = self.parseData(
+			self.executeBashScriptOnServer("git-requests.sh"))
 		self.header = ["date", "Git requests"]
 		self.data.append(
 			[

--- a/updater/reports/ReportGitRequests.py
+++ b/updater/reports/ReportGitRequests.py
@@ -6,8 +6,7 @@ class ReportGitRequests(ReportDaily):
 		return "git-requests"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("git-requests.sh")))
+		self.detailedHeader, newData = self.parseData(self.executeScript("git-requests.sh"))
 		self.header = ["date", "Git requests"]
 		self.data.append(
 			[

--- a/updater/reports/ReportGitVersions.py
+++ b/updater/reports/ReportGitVersions.py
@@ -10,5 +10,4 @@ class ReportGitVersions(Report):
 		pass
 
 	def updateData(self):
-		self.header, self.data = self.parseData(
-			self.executeScript(self.scriptPath("git-versions.sh")))
+		self.header, self.data = self.parseData(self.executeScript("git-versions.sh"))

--- a/updater/reports/ReportGitVersions.py
+++ b/updater/reports/ReportGitVersions.py
@@ -10,4 +10,4 @@ class ReportGitVersions(Report):
 		pass
 
 	def updateData(self):
-		self.header, self.data = self.parseData(self.executeScript("git-versions.sh"))
+		self.header, self.data = self.parseData(self.executeBashScriptOnServer("git-versions.sh"))

--- a/updater/reports/ReportGitVersionsNew.py
+++ b/updater/reports/ReportGitVersionsNew.py
@@ -6,8 +6,7 @@ class ReportGitVersionsNew(ReportDaily):
 		return "git-versions-new"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("git-versions.sh")))
+		newHeader, newData = self.parseData(self.executeScript("git-versions.sh"))
 
 		self.header = ["date"] + newHeader
 

--- a/updater/reports/ReportGitVersionsNew.py
+++ b/updater/reports/ReportGitVersionsNew.py
@@ -6,7 +6,7 @@ class ReportGitVersionsNew(ReportDaily):
 		return "git-versions-new"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(self.executeScript("git-versions.sh"))
+		newHeader, newData = self.parseData(self.executeBashScriptOnServer("git-versions.sh"))
 
 		self.header = ["date"] + newHeader
 

--- a/updater/reports/ReportOrgActivity.py
+++ b/updater/reports/ReportOrgActivity.py
@@ -6,7 +6,7 @@ class ReportOrgActivity(ReportDaily):
 		return "organization-activity"
 
 	def updateDailyData(self):
-		newHeader, newData = self.parseData(self.executeQuery(self.query()))
+		newHeader, newData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.header = newHeader if newHeader else self.header
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())

--- a/updater/reports/ReportOrgCollaboration.py
+++ b/updater/reports/ReportOrgCollaboration.py
@@ -137,7 +137,7 @@ class ReportOrgCollaboration(Report):
 				target.org_id'''
 
 	def orgCollaborationMatrix(self, timeRange):
-		_, newData = self.parseData(self.executeQuery(self.collaboration(timeRange)))
+		_, newData = self.parseData(self.executeDatabaseQueryOnServer(self.collaboration(timeRange)))
 		collab = {}
 		orgs = []
 

--- a/updater/reports/ReportOrgOwners.py
+++ b/updater/reports/ReportOrgOwners.py
@@ -11,7 +11,7 @@ class ReportOrgOwners(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeGHEConsole('''
+			self.executeRubyScriptOnServer('''
 				puts "organization\towner(s)\n"
 				User.where(:type => "Organization")
 				    .where("''' + self.andExcludedEntities("login", "").replace('"', '\\"') + '''")

--- a/updater/reports/ReportOrgsAbandoned.py
+++ b/updater/reports/ReportOrgsAbandoned.py
@@ -8,7 +8,7 @@ class ReportOrgsAbandoned(ReportDaily):
 		return "organizations-abandoned"
 
 	def updateDailyData(self):
-		self.detailedHeader, self.detailedData = self.parseData(self.executeQuery(self.query()))
+		self.detailedHeader, self.detailedData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.header = ["date", "abandoned organizations"]
 		self.data.append([str(self.yesterday()), len(self.detailedData)])
 		self.truncateData(self.timeRangeTotal())

--- a/updater/reports/ReportOrgsTotal.py
+++ b/updater/reports/ReportOrgsTotal.py
@@ -6,7 +6,7 @@ class ReportOrgsTotal(ReportDaily):
 		return "orgs-total"
 
 	def updateDailyData(self):
-		self.header, newData = self.parseData(self.executeQuery(self.query()))
+		self.header, newData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportPRByOrg.py
+++ b/updater/reports/ReportPRByOrg.py
@@ -12,7 +12,7 @@ class ReportPRByOrg(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])))
+			self.executeDatabaseQueryOnServer(self.query([self.daysAgo(30), self.yesterday()])))
 
 	# Collects the number of merged and new pull requests per organization
 	def query(self, timeRange):

--- a/updater/reports/ReportPRByRepo.py
+++ b/updater/reports/ReportPRByRepo.py
@@ -12,7 +12,7 @@ class ReportPRByRepo(Report):
 
 	def updateData(self):
 		self.header, self.data = self.parseData(
-			self.executeQuery(self.query([self.daysAgo(30), self.yesterday()])))
+			self.executeDatabaseQueryOnServer(self.query([self.daysAgo(30), self.yesterday()])))
 
 	# Collects the number of merged and new pull requests per repository
 	def query(self, timeRange):

--- a/updater/reports/ReportPRHistory.py
+++ b/updater/reports/ReportPRHistory.py
@@ -8,7 +8,7 @@ class ReportPRHistory(ReportDaily):
 	def updateDailyData(self):
 		# Collect the missing data that should be added with this update
 		self.header, newData = self.parseData(
-			self.executeQuery(self.query(self.timeRangeToUpdate())))
+			self.executeDatabaseQueryOnServer(self.query(self.timeRangeToUpdate())))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportPRUsage.py
+++ b/updater/reports/ReportPRUsage.py
@@ -18,9 +18,9 @@ class ReportPRUsage(ReportDaily):
 			while date < range[1]:
 				days_in_month = calendar.monthrange(date.year, date.month)[1]
 				date += datetime.timedelta(days_in_month)
-				_, newData = self.parseData(self.executeQuery(self.query(date)))
+				_, newData = self.parseData(self.executeDatabaseQueryOnServer(self.query(date)))
 				self.data.extend(newData)
-		self.header, newData = self.parseData(self.executeQuery(self.query(self.yesterday())))
+		self.header, newData = self.parseData(self.executeDatabaseQueryOnServer(self.query(self.yesterday())))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportRepoActivity.py
+++ b/updater/reports/ReportRepoActivity.py
@@ -13,12 +13,12 @@ class ReportRepoActivity(ReportDaily):
 		return "repository-activity"
 
 	def updateDailyData(self):
-		self.header, newData = self.parseData(self.executeQuery(self.query()))
+		self.header, newData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()
 		self.detailedHeader, self.detailedData = self.parseData(
-			self.executeQuery(self.detailedQuery()))
+			self.executeDatabaseQueryOnServer(self.detailedQuery()))
 
 	# Collects active repositories for a user type (user/organization)
 	# given a time range

--- a/updater/reports/ReportRepoSize.py
+++ b/updater/reports/ReportRepoSize.py
@@ -7,7 +7,7 @@ class ReportRepoSize(ReportDaily):
 
 	def updateDailyData(self):
 		self.detailedHeader, self.detailedData = self.parseData(
-			self.executeGHEConsole('''
+			self.executeRubyScriptOnServer('''
 				puts "repository\tarchived?\trepository size [MB]\n"
 				Repository
 					.select{ |repo|

--- a/updater/reports/ReportRepoUsage.py
+++ b/updater/reports/ReportRepoUsage.py
@@ -8,7 +8,7 @@ class ReportRepoUsage(ReportDaily):
 		return "repository-usage"
 
 	def updateDailyData(self):
-		self.header, newData = self.parseData(self.executeQuery(self.query()))
+		self.header, newData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportReposPersonalNonOwnerPushes.py
+++ b/updater/reports/ReportReposPersonalNonOwnerPushes.py
@@ -9,7 +9,7 @@ class ReportReposPersonalNonOwnerPushes(ReportDaily):
 		return "repositories-personal-nonowner-pushes"
 
 	def updateDailyData(self):
-		self.detailedHeader, self.detailedData = self.parseData(self.executeQuery(self.query()))
+		self.detailedHeader, self.detailedData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.header = ["date", "personal repositories with nonowner pushes"]
 		self.data.append([str(self.yesterday()), len(self.detailedData)])
 		self.truncateData(self.timeRangeTotal())

--- a/updater/reports/ReportRepositoryHistory.py
+++ b/updater/reports/ReportRepositoryHistory.py
@@ -6,7 +6,7 @@ class ReportRepositoryHistory(ReportDaily):
 		return "repository-history"
 
 	def updateDailyData(self):
-		self.header, newData = self.parseData(self.executeQuery(self.query()))
+		self.header, newData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportTeamsLegacy.py
+++ b/updater/reports/ReportTeamsLegacy.py
@@ -10,7 +10,7 @@ class ReportTeamsLegacy(ReportDaily):
 
 	def updateDailyData(self):
 		self.detailedHeader, self.detailedData = self.parseData(
-			self.executeGHEConsole('''
+			self.executeRubyScriptOnServer('''
 				puts "organization\tteam\tmembers\n"
 				User.where(:type => "Organization")
 				    .order("login")

--- a/updater/reports/ReportTeamsTotal.py
+++ b/updater/reports/ReportTeamsTotal.py
@@ -6,7 +6,7 @@ class ReportTeamsTotal(ReportDaily):
 		return "teams-total"
 
 	def updateDailyData(self):
-		self.header, newData = self.parseData(self.executeQuery(self.query()))
+		self.header, newData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()

--- a/updater/reports/ReportTokenlessAuth.py
+++ b/updater/reports/ReportTokenlessAuth.py
@@ -6,7 +6,8 @@ class ReportTokenlessAuth(ReportDaily):
 		return "tokenless-authentication"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(self.executeScript("tokenless-auth.sh"))
+		self.detailedHeader, newData = self.parseData(
+			self.executeBashScriptOnServer("tokenless-auth.sh"))
 		self.header = ["date", "tokenless authentications"]
 		self.data.append(
 			[

--- a/updater/reports/ReportTokenlessAuth.py
+++ b/updater/reports/ReportTokenlessAuth.py
@@ -6,8 +6,7 @@ class ReportTokenlessAuth(ReportDaily):
 		return "tokenless-authentication"
 
 	def updateDailyData(self):
-		self.detailedHeader, newData = self.parseData(
-			self.executeScript(self.scriptPath("tokenless-auth.sh")))
+		self.detailedHeader, newData = self.parseData(self.executeScript("tokenless-auth.sh"))
 		self.header = ["date", "tokenless authentications"]
 		self.data.append(
 			[

--- a/updater/reports/ReportUsers.py
+++ b/updater/reports/ReportUsers.py
@@ -6,7 +6,7 @@ class ReportUsers(ReportDaily):
 		return "users"
 
 	def updateDailyData(self):
-		self.header, newData = self.parseData(self.executeQuery(self.query()))
+		self.header, newData = self.parseData(self.executeDatabaseQueryOnServer(self.query()))
 		self.data.extend(newData)
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()


### PR DESCRIPTION
The function `executeScript` used to have a double role, as it was in charge of executing both Unix commands on the server (locally or by using a local connection) but also Bash scripts.

This was confusing per se, but had a few side effects that might have been unexpected to developers looking at the code.

First of all, the optional `stdin` argument was completely ignored when executing Bash scripts on the server. The reason for that is that `stdin` was used to pass the script’s content to the server (using the `-s` option provided by Bash). In a sense, the interface of this function was misleading as a result of this.

Also, when using `executeScript` to run regular Unix commands, unnecessary file look-ups were made.

To address these issues, this replaces the `executeScript` method with two new ones: `executeCommandOnServer` (which executes regular Unix commands) and `executeBashScriptOnServer` (which executes Bash scripts and currently does not accept stdin because of the limitation mentioned above).

In addition to that, other similar functions are renamed to `executeDatabaseQueryOnServer` and `executeRubyScriptOnServer` for consistency and clarity.

Finally, scripts are now read from the `scripts/` directory by default to simplify calls of `executeScriptOnServer`.