### PR TITLE
Fix Ruby script execution

### DIFF
--- a/updater/reports/Report.py
+++ b/updater/reports/Report.py
@@ -92,13 +92,18 @@ class Report(object):
 
 		return self.executeCommandOnServer(command, stdin)
 
+	# Executes a Ruby script on the server in the production environment. stdin cannot be supplied
+	# currently, as the stdin channel is used to pass the script content to the server in a remote
+	# run, where SSH is used
 	def executeRubyScriptOnServer(self, script):
-		# Escape the Ruby script, as it is going to be sent as a string on the command line
-		script = script.replace('\\t', '\\\\t').replace('\\n', '\\\\n')
+		stdin = script
 
-		command = ["github-env", "bin/runner", "-e", "production", "'" + script + "'"]
+		# By running github-enb with a trailing - on the command line, the Ruby script to be
+		# executed is read from stdin. As a result, the stdin channel can’t be used for anything
+		# else currently
+		command = ["github-env", "bin/runner", "-e", "production", "-"]
 
-		return self.executeCommandOnServer(command)
+		return self.executeCommandOnServer(command, stdin)
 
 	# Executes a database query, given as a string
 	def executeDatabaseQueryOnServer(self, query):


### PR DESCRIPTION
Ruby scripts were executed on the server by passing them to the GitHub environment runner as a command-line argument. This caused trouble with newlines, which were escaped with additional backslashes. However, it appears that this escaping may not be correct, depending on whether the command is run over SSH or not.

With this change, the Ruby script is not provided as a command-line argument anymore. Instead, the GitHub environment runner is instructed to read the Ruby script from `stdin`. This solution has the benefit of being more robust concerning newlines, as those don’t need to be escaped anymore. Also, this solution works regardless of other potentially confounding factors such as running the updater in a `systemd` environment vs. a remote shell or subprocess implementation differences between Python versions.