### PR TITLE
Fix git-protocols, git-requests, api-requests, api-requests-by-user for GHES 3.11+

### DIFF
--- a/updater/scripts/api-requests-by-user.sh
+++ b/updater/scripts/api-requests-by-user.sh
@@ -7,9 +7,9 @@
 echo -e "user\trequests"
 
 zcat -f /var/log/github/unicorn.log.1* |
-    grep -F 'request_category=api' |
+    grep -F 'request_category="api"' |
     grep -Fv 'remote_address=127.0.0.1' |
-    grep -oP 'current_user=\K\S+' |
+    grep -oP 'gh.actor.login=\K\S+' |
     grep -Fvx 'nil' |
     sort |
     uniq -ic |

--- a/updater/scripts/api-requests.sh
+++ b/updater/scripts/api-requests.sh
@@ -5,7 +5,7 @@
 echo -e "resource\ttype\tsource IP\trequests"
 
 zcat -f /var/log/haproxy.log.1* |
-    perl -ne 'print if s/.*haproxy\[\d+\]: ([^:]+).*\/api\/v3\/([^\/\? ]+)\/([^\/\? ]+?(\/[^\/\? ]+)).*/\1 \2 \3/' |
+    perl -ne 'print if s/.*haproxy-frontend\[\d+\]: ([^:]+).*\/api\/v3\/([^\/\? ]+)\/([^\/\? ]+?(\/[^\/\? ]+)).*/\1 \2 \3/' |
     grep -v '^127.0.0.1' |
     sort |
     uniq -ic |

--- a/updater/scripts/git-protocol.sh
+++ b/updater/scripts/git-protocol.sh
@@ -4,7 +4,9 @@
 #
 echo -e "Git protocol\tconnections"
 
-zcat -f /var/log/syslog.1* |
+TMPDIR=`mktemp -d`
+sudo cp -a /var/log/babeld/babeld.log.1.gz $TMPDIR
+zcat -f $TMPDIR/babeld.log.1.gz |
 	# Remove the leading time stamp
 	cut --characters 17- |
 	# Remove the host name
@@ -15,3 +17,5 @@ zcat -f /var/log/syslog.1* |
 	sort |
 	uniq -c |
 	awk '{printf("%s\t%s\n",$2,$1)}'
+sudo rm -f $TMPDIR/babeld.log.1.gz
+rmdir $TMPDIR

--- a/updater/scripts/git-requests.sh
+++ b/updater/scripts/git-requests.sh
@@ -4,7 +4,9 @@
 #
 echo -e "repository\tsource IP\trequests"
 
-zcat -f /var/log/syslog.1* |
+TMPDIR=`mktemp -d`
+sudo cp -a /var/log/babeld/babeld.log.1.gz $TMPDIR
+zcat -f $TMPDIR/babeld.log.1.gz |
 	# Remove the leading time stamp
 	cut --characters 17- |
 	# Remove the host name
@@ -16,3 +18,5 @@ zcat -f /var/log/syslog.1* |
 	uniq -ic |
 	sort -rn |
 	awk '{printf("%s\t%s\t%s\n",$3,$2,$1)}'
+sudo rm -f $TMPDIR/babeld.log.1.gz
+rmdir $TMPDIR


### PR DESCRIPTION
Since Github Enterprise Server 3.11 and later, log locations and formats have changed.  For example, babeld no longer logs to /var/log/syslog.  Instead, it logs to /var/log/babeld/babeld.log.  Also, current_user is no longer in /var/log/github/unicorn.log; instead it is gh.actor.login.  Lastly, haproxy is now called haproxy-frontend.

This PR includes fixes for four scripts:
- api-requests-by-user.sh
- api-requests.sh
- git-protocol.sh
- git-requests.sh

Unfortunately, the admin user no longer has privileges to read babeld.log, but it has sudo NOPASSWD capability.  The git-protocol.sh and git-requests.sh use mktemp and sudo to copy the babeld.log to a temporary directory, parse it and remove it.
